### PR TITLE
GUAC-1128: Bump versions to 0.9.6 where appropriate.

### DIFF
--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -60,7 +60,7 @@
     &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-auth-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.3&lt;/version>
+    &lt;version>0.9.6&lt;/version>
     &lt;name>guacamole-auth-tutorial&lt;/name>
     &lt;url>http://guac-dev.org/&lt;/url>
 
@@ -90,14 +90,14 @@
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common&lt;/artifactId>
-            &lt;version>0.9.3&lt;/version>
+            &lt;version>0.9.6&lt;/version>
         &lt;/dependency>
 
         &lt;!-- Guacamole Extension API -->
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.3&lt;/version>
+            &lt;version>0.9.6&lt;/version>
         &lt;/dependency>
 
     &lt;/dependencies>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -420,8 +420,8 @@
                 of a <filename>.tar.gz</filename> archive which you can extract from the command
                 line:</para>
             <informalexample>
-                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.4.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-server-0.9.4/</userinput>
+                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.6.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-server-0.9.6/</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
             <para>If you want the absolute latest code, and don't care that the code hasn't been as
@@ -473,7 +473,7 @@ checking whether build environment is sane... yes
 ...
 
 ------------------------------------------------
-guacamole-server version 0.9.4
+guacamole-server version 0.9.6
 ------------------------------------------------
 
    Library status:
@@ -640,8 +640,8 @@ make[1]: Leaving directory `/home/zhz/guacamole/guacamole-server'</computeroutpu
                 <filename>.tar.gz</filename> archive which you can extract from the command
             line:</para>
         <informalexample>
-            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.4.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-client-0.9.4/</userinput>
+            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.6.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-client-0.9.6/</userinput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>As with <package>guacamole-server</package>, if you want the absolute latest code, and
@@ -702,7 +702,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
             container.</para>
         <para>You will probably have to do this as the root user:</para>
         <informalexample>
-            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.4.war /var/lib/tomcat7/webapps/guacamole.war</userinput>
+            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.6.war /var/lib/tomcat7/webapps/guacamole.war</userinput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>The Guacamole web application also depends on a configuration file,
@@ -789,7 +789,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 Starting Tomcat... OK</computeroutput>
 <prompt>#</prompt> <userinput>/etc/init.d/guacd start</userinput>
 <computeroutput>Starting guacd: SUCCESS
-guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.4 started</computeroutput>
+guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.6 started</computeroutput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>If you want Guacamole to start on boot, you will need to configure the Tomcat and

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -69,19 +69,19 @@
         <para>The contents of for a MySQL database should match the files shown here:</para>
         <informalexample>
             <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-jdbc-mysql-0.9.5.jar
+<computeroutput>guacamole-auth-jdbc-mysql-0.9.6.jar
 mysql-connector-java-5.1.23-bin.jar</computeroutput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>For PostgreSQL, the contents should match the files shown here:</para>
         <informalexample>
             <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-jdbc-postgresql-0.9.5.jar
+<computeroutput>guacamole-auth-jdbc-postgresql-0.9.6.jar
 postgresql-9.4-1201.jdbc41.jar</computeroutput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>Each of the <filename>.jar</filename> files above is either the authentication module
-            itself (<filename>guacamole-auth-jdbc-*-0.9.5.jar</filename>) or the corresponding JDBC
+            itself (<filename>guacamole-auth-jdbc-*-0.9.6.jar</filename>) or the corresponding JDBC
             driver. <emphasis>If any of these files is missing, authentication will not
                 work!</emphasis></para>
     </section>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -52,10 +52,10 @@
             are no conflicts in between multiple versions of <package>guacamole-auth-ldap</package>.
             The contents should match at least the files shown here:</para>
         <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-ldap-0.8.0.jar  jldap-4.3.jar</computeroutput>
+<computeroutput>guacamole-auth-ldap-0.9.6.jar  jldap-4.3.jar</computeroutput>
 <prompt>$</prompt></screen>
         <para>Each of the <filename>.jar</filename> files above is either the LDAP authentication
-            module itself (<filename>guacamole-auth-ldap-0.8.0.jar</filename>) or a dependency. They
+            module itself (<filename>guacamole-auth-ldap-0.9.6.jar</filename>) or a dependency. They
             must all be placed in Guacamole's <property>lib-directory</property> for the LDAP
             authentication to work.</para>
         <section>

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -53,10 +53,10 @@
             extension itself. After copying this file in place, check that the contents match the
             listing shown here:</para>
         <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-noauth-0.8.0.jar</computeroutput>
+<computeroutput>guacamole-auth-noauth-0.9.6.jar</computeroutput>
 <prompt>$</prompt></screen>
         <para>If there are other <filename>.jar</filename> files present beyond the "noauth"
-            authentication module itself (<filename>guacamole-auth-noauth-0.8.0.jar</filename>), it
+            authentication module itself (<filename>guacamole-auth-noauth-0.9.6.jar</filename>), it
             should still work. You would only have problems if two different versions of "noauth"
             were present.</para>
         <section>

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -112,7 +112,7 @@
     &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-tutorial&lt;/artifactId>
     &lt;packaging>war&lt;/packaging>
-    &lt;version>0.9.3&lt;/version>
+    &lt;version>0.9.6&lt;/version>
     &lt;name>guacamole-tutorial&lt;/name>
     &lt;url>http://guac-dev.org/&lt;/url>
 
@@ -302,7 +302,7 @@
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common&lt;/artifactId>
-            &lt;version>0.9.3&lt;/version>
+            &lt;version>0.9.6&lt;/version>
             &lt;scope>compile&lt;/scope>
         &lt;/dependency>
 
@@ -310,7 +310,7 @@
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common-js&lt;/artifactId>
-            &lt;version>0.9.3&lt;/version>
+            &lt;version>0.9.5&lt;/version>
             &lt;type>zip&lt;/type>
             &lt;scope>runtime&lt;/scope>
         &lt;/dependency>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -3,7 +3,7 @@
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <info>
         <title>Guacamole Manual</title>
-        <edition>0.9.5</edition>
+        <edition>0.9.6</edition>
         <author>
             <personname><firstname>Michael</firstname>
                 <surname>Jumper</surname></personname>
@@ -41,7 +41,7 @@
             application, etc.) to give a good starting point beyond simply looking at the Guacamole
             codebase.</para>
         <para>This particular edition of the <citetitle>Guacamole Manual</citetitle> covers
-            Guacamole version 0.9.5. New releases which create new features or break compatibility
+            Guacamole version 0.9.6. New releases which create new features or break compatibility
             will result in new editions of the user's guide, as will any necessary corrections. As
             the official documentation for the project, this book will always be freely available in
             its entirety online.</para>


### PR DESCRIPTION
Only guacamole-common-js remains at 0.9.5. Everything else is now 0.9.6.
