### PR TITLE
GUAC-1147: Fix build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Build entire manual
 #
 
-all: html/index.html
+all: html/index.html html/gug.css html/images
 	
 #
 # Clean build artifacts
@@ -29,4 +29,10 @@ FILES=$(shell find -name "*.xml")
 
 html/index.html: $(FILES) src/site.xslt docbook-xsl
 	cd src; xsltproc -o ../html/ --xinclude site.xslt gug.xml
+
+html/gug.css: src/gug.css
+	cp src/gug.css html/
+
+html/images: src/images
+	cp -r src/images html/
 

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,16 @@ docbook-xsl:
 # HTML manual build
 #
 
-# All XML files which the build depends on
-FILES=$(shell find -name "*.xml")
+# All files which the build depends on
+XML_FILES=$(shell find -name "*.xml")
+PNG_FILES=$(shell find -name "*.png")
 
-html/index.html: $(FILES) src/site.xslt docbook-xsl
+html/index.html: $(XML_FILES) src/site.xslt docbook-xsl
 	cd src; xsltproc -o ../html/ --xinclude site.xslt gug.xml
 
 html/gug.css: src/gug.css
 	cp src/gug.css html/
 
-html/images: src/images
+html/images: src/images $(PNG_FILES)
 	cp -r src/images html/
 

--- a/src/chapters/architecture.xml
+++ b/src/chapters/architecture.xml
@@ -16,7 +16,7 @@
         gruntwork performed by lower-level components.<informalfigure>
             <mediaobject>
                 <imageobject>
-                    <imagedata fileref="../images/guac-arch.png" width="2.5in"/>
+                    <imagedata fileref="images/guac-arch.png" width="2.5in"/>
                 </imageobject>
             </mediaobject>
         </informalfigure></para>

--- a/src/chapters/using.xml
+++ b/src/chapters/using.xml
@@ -259,7 +259,7 @@ $</screen>
         <informalfigure>
             <mediaobject>
                 <imageobject>
-                    <imagedata fileref="../images/manage-button.png" format="PNG" contentwidth="3in"
+                    <imagedata fileref="images/manage-button.png" format="PNG" contentwidth="3in"
                     />
                 </imageobject>
                 <caption>
@@ -290,7 +290,7 @@ $</screen>
             <informalfigure>
                 <mediaobject>
                     <imageobject>
-                        <imagedata fileref="../images/manage-users.png" format="PNG"
+                        <imagedata fileref="images/manage-users.png" format="PNG"
                             contentwidth="3in"/>
                     </imageobject>
                     <caption>
@@ -307,7 +307,7 @@ $</screen>
             <informalfigure>
                 <mediaobject>
                     <imageobject>
-                        <imagedata fileref="../images/edit-user.png" format="PNG" contentwidth="2in"
+                        <imagedata fileref="images/edit-user.png" format="PNG" contentwidth="2in"
                         />
                     </imageobject>
                     <caption>
@@ -332,7 +332,7 @@ $</screen>
             <informalfigure>
                 <mediaobject>
                     <imageobject>
-                        <imagedata fileref="../images/manage-connections.png" format="PNG"
+                        <imagedata fileref="images/manage-connections.png" format="PNG"
                             contentwidth="3in"/>
                     </imageobject>
                     <caption>
@@ -353,7 +353,7 @@ $</screen>
             <informalfigure>
                 <mediaobject>
                     <imageobject>
-                        <imagedata fileref="../images/edit-connection.png" format="PNG"
+                        <imagedata fileref="images/edit-connection.png" format="PNG"
                             contentwidth="2in"/>
                     </imageobject>
                     <caption>
@@ -381,7 +381,7 @@ $</screen>
                 <informalfigure>
                     <mediaobject>
                         <imageobject>
-                            <imagedata fileref="../images/edit-group.png" format="PNG"
+                            <imagedata fileref="images/edit-group.png" format="PNG"
                                 contentwidth="3in"/>
                         </imageobject>
                         <caption>

--- a/src/gug.css
+++ b/src/gug.css
@@ -1,0 +1,81 @@
+
+body {
+
+    color: black;
+    background: white;
+
+    font-family: 'FreeSans', 'Liberation Sans', 'Arial', 'Helvetica', sans-serif;
+    font-size: 10pt;
+    text-align: justify;
+    text-rendering: optimizeLegibility;
+
+    margin: 0;
+    padding: 0;
+
+}
+
+/* Green links */
+a[href]         { color: #080; }
+a[href]:visited { color: #884; }
+
+div#content {
+
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: auto;
+    margin-right: auto;
+
+    max-width: 25cm;
+    padding: 1em;
+
+}
+
+/* DOCBOOK */
+
+.navheader hr, .navfooter hr {
+    border: 0;
+    border-bottom: 1px solid black;
+}
+
+.programlisting, .screen {
+    background: black;
+    color: silver;
+    padding: 1em;
+    border-radius: 0.5em;
+    -moz-border-radius: 0.5em;
+    -webkit-border-radius: 0.5em;
+}
+
+.book .titlepage {
+    text-align: center;
+    padding: 2em;
+}
+
+.titlepage hr {
+    display: none;
+}
+
+.mediaobject {
+    text-align: center;
+    float: none;
+    margin: 1em;
+}
+
+.caption {
+    font-size: 0.8em;
+    font-style: italic;
+}
+
+.navfooter, .section {
+    clear: both;
+}
+
+.table-contents table {
+    border: 1px solid black;
+    border-collapse: collapse;
+}
+
+.table-contents td, .table-contents th {
+    padding: 0.5em;
+}
+

--- a/src/site.xslt
+++ b/src/site.xslt
@@ -53,20 +53,6 @@
         <xsl:text disable-output-escaping="yes"><![CDATA[
 
             </div></div>
-
-            <!-- Piwik --> 
-            <script type="text/javascript">
-                var pkBaseURL = (("https:" == document.location.protocol) ? "https://guac-dev.org/piwik/" : "http://guac-dev.org/piwik/");
-                document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-            </script><script type="text/javascript">
-                try {
-                    var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 1);
-                    piwikTracker.trackPageView();
-                    piwikTracker.enableLinkTracking();
-                } catch( err ) {}
-            </script><noscript><p><img src="http://guac-dev.org/piwik/piwik.php?idsite=1" style="border:0" alt="" /></p></noscript>
-            <!-- End Piwik Tracking Code -->
-
         ]]></xsl:text>
     </xsl:template>
 


### PR DESCRIPTION
The current documentation build is incorrect for the following reasons:
1. Referenced images are missing
2. The `gug.css` file is not included at all
3. `site.xslt` adds Piwik tracking code to all output HTML

This change adds the images to the build, adds the missing `gug.css`, and removes the tracking code from `site.xslt`. It makes perfect sense to have such tracking on the main guac-dev.org site, but it really shouldn't be in the source now that the source is on GitHub.
