### PR TITLE
GUAC-794: Add Italian keyboard to list of supported layouts.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -992,6 +992,18 @@ basic-user-mapping: /etc/guacamole/user-mapping.xml</programlisting>
                                         </listitem>
                                     </varlistentry>
                                     <varlistentry>
+                                        <term><constant>it-it-qwerty</constant></term>
+                                        <listitem>
+                                            <para>Italian keyboard</para>
+                                        </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                        <term><constant>sv-se-qwerty</constant></term>
+                                        <listitem>
+                                            <para>Swedish keyboard</para>
+                                        </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
                                         <term><constant>failsafe</constant></term>
                                         <listitem>
                                             <para>Unknown keyboard - this option sends only Unicode


### PR DESCRIPTION
Adds the Swedish keyboard, too, which has been missing since we added support.
