### PR TITLE
GUAC-587: Update documentation regarding authentication extensions.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -263,12 +263,17 @@ guacd-port:     4822</programlisting>
             <indexterm>
                 <primary>user-mapping.xml</primary>
             </indexterm>
-            <para>The default authentication provider used by Guacamole reads
-                all username, password, and configuration information from a
-                file called the "user mapping" (typically named
-                    <filename>user-mapping.xml</filename>). An example of this
-                file is included with Guacamole, and looks something like
-                this:</para>
+            <para>The default authentication provider used by Guacamole reads all username,
+                password, and configuration information from a file called the "user mapping". By
+                default, Guacamole will look for this file at
+                    <filename>GUACAMOLE_HOME/user-mapping.xml</filename>, but this can be overridden
+                by specifying the location with the <property>user-mapping</property> property
+                within guacamole.properties:</para>
+            <informalexample>
+                <programlisting>user-mapping: <replaceable>/path/to/user-mapping.xml</replaceable></programlisting>
+            </informalexample>
+            <para>An example of a user mapping file is included with Guacamole, and looks something
+                like this:</para>
             <programlisting>&lt;user-mapping>
 	
     &lt;!-- Per-user authentication and config information -->

--- a/src/chapters/guacamole-ext.xml
+++ b/src/chapters/guacamole-ext.xml
@@ -43,10 +43,10 @@
             the extension are determined by the extension manifest alone.</para>
         <section>
             <title>Extension manifest</title>
-            <para>The Guacamole extension manifest is a single JSON file, guac-manifest.json, which
-                describes the location of each resource, the type of each resource, and the version
-                of Guacamole that the extension was built for. The manifest can contain the
-                following properties:</para>
+            <para>The Guacamole extension manifest is a single JSON file,
+                    <filename>guac-manifest.json</filename>, which describes the location of each
+                resource, the type of each resource, and the version of Guacamole that the extension
+                was built for. The manifest can contain the following properties:</para>
             <informaltable frame="all">
                 <tgroup cols="2">
                     <colspec colname="c1" colnum="1" colwidth="1*"/>
@@ -198,7 +198,8 @@
                 <classname>LocalEnvironment</classname> implementation of this interface. Through
                 <classname>Environment</classname>, you can access all properties declared within
                 <filename>guacamole.properties</filename>, determine the proper hostname/port of
-            guacd, and access the contents of <varname>GUACAMOLE_HOME</varname>.</para>
+                <package>guacd</package>, and access the contents of
+                <varname>GUACAMOLE_HOME</varname>.</para>
         <section xml:id="simple-config">
             <title>Custom properties</title>
             <para>If your extension requires generic, unstructured configuration parameters,
@@ -293,7 +294,7 @@
         <section xml:id="advanced-config">
             <title>Advanced configuration</title>
             <para>If you need more structured data than provided by simple properties, you can place
-                completely arbitrary files in a hierarchy of your chosing anywhere within
+                completely arbitrary files in a hierarchy of your choosing anywhere within
                     <varname>GUACAMOLE_HOME</varname> as long as you avoid placing your files in
                 directories reserved for other purposes as described above.</para>
             <para>The Environment interface exposes the location of

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -16,29 +16,51 @@
         available from the project website. These extensions allows users and connections to be
         managed from within the web application. Unlike the default, XML-driven authentication
         module, all changes to users and connections take effect immediately; users need not logout
-        and back in in order to see new connections.</para>
+        and back in to see new connections.</para>
     <para>The official database authentication also supports load balancing through the use of
         "balancing groups". When a balancing group is created, it can be used like any other
         connection, but will use the least-used of its underlying connections, spreading load evenly
         across any connections contained within.</para>
-    <section xml:id="jdbc-auth-installation">
-        <title>Installing database support</title>
-        <para>The database authentication modules are not included in the main Guacamole bundle nor
-            are they enabled by default. You must use the download link provided in the downloads
-            section of the main Guacamole site.</para>
-        <para>The downloaded <filename>.tar.gz</filename> file will contain several
-            directories:</para>
+    <para>To use the database authentication extension, you will need:</para>
+    <orderedlist>
+        <listitem>
+            <para>A supported database - currently MariaDB, MySQL, or PostgreSQL.</para>
+        </listitem>
+        <listitem>
+            <para>Sufficient permission to create new databases, to create new users, and to grant
+                those users permissions.</para>
+        </listitem>
+        <listitem>
+            <para>Network access to the database from the Guacamole server.</para>
+        </listitem>
+    </orderedlist>
+    <important>
+        <para>This chapter involves modifying the contents of <varname>GUACAMOLE_HOME</varname> -
+            the Guacamole configuration directory. If you are unsure where
+                <varname>GUACAMOLE_HOME</varname> is located on your system, please consult <xref
+                linkend="configuring-guacamole"/> before proceeding.</para>
+    </important>
+    <section xmlns:xlink="http://www.w3.org/1999/xlink">
+        <title>Downloading the database authentication extension</title>
+        <para>The database authentication extension is available separately from the main
+                <filename>guacamole.war</filename>. The link for this and all other
+            officially-supported and compatible extensions for a particular version of Guacamole are
+            provided on the release notes for that version. You can find the release notes for
+            current versions of Guacamole here: <link xlink:href="http://guac-dev.org/releases/"
+                >http://guac-dev.org/releases/</link>.</para>
+        <para>The database authentication extension is packaged as a <filename>.tar.gz</filename>
+            file containing:</para>
         <variablelist>
             <varlistentry>
                 <term><filename>mysql/</filename></term>
                 <listitem>
-                    <para>Contains the MySQL authentication module as a <filename>.jar</filename>
-                        file, along with a <filename>schema/</filename> directory containing the SQL
-                        scripts required to set up the database.</para>
+                    <para>Contains the MySQL/MariaDB authentication extension as a self-contained
+                            <filename>.jar</filename> file, along with a
+                            <filename>schema/</filename> directory containing the SQL scripts
+                        required to set up the database.</para>
                     <para><emphasis>The MySQL JDBC connector is not included.</emphasis> You must
                         obtain the JDBC connector <filename>.jar</filename> from within the
                         "Connector/J" archive downloadable from <link
-                            xmlns:xlink="http://www.w3.org/1999/xlink"
                             xlink:href="http://dev.mysql.com/downloads/connector/j/">MySQL's
                             website</link>.</para>
                 </listitem>
@@ -46,56 +68,32 @@
             <varlistentry>
                 <term><filename>postgresql/</filename></term>
                 <listitem>
-                    <para>Contains the PostgreSQL authentication module as a
+                    <para>Contains the PostgreSQL authentication extension as a self-contained
                             <filename>.jar</filename> file, along with a
                             <filename>schema/</filename> directory containing the SQL scripts
                         required to set up the database.</para>
                     <para><emphasis>The PostgreSQL JDBC driver is not included.</emphasis> You must
                         obtain the JDBC driver <filename>.jar</filename> from <link
-                            xmlns:xlink="http://www.w3.org/1999/xlink"
                             xlink:href="https://jdbc.postgresql.org/download.html#current"
                             >PostgreSQL's website</link>. The proper <filename>.jar</filename> file
                         depends on the version of Java you have installed. </para>
                 </listitem>
             </varlistentry>
         </variablelist>
-        <para>The authentication module <filename>.jar</filename> file for your database must be
-            copied into the directory specified by the <property>lib-directory</property> property
-            in <filename>guacamole.properties</filename>, along with the your database's JDBC
-            driver. If this property is not specified, you will need to add it. On Linux servers,
-                <filename>/var/lib/guacamole/classpath</filename> is a good choice, but it can be
-            whatever you like.</para>
-        <para>After copying the files in place, check to make sure everything looks sane.</para>
-        <para>The contents of for a MySQL database should match the files shown here:</para>
-        <informalexample>
-            <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-jdbc-mysql-0.9.6.jar
-mysql-connector-java-5.1.23-bin.jar</computeroutput>
-<prompt>$</prompt></screen>
-        </informalexample>
-        <para>For PostgreSQL, the contents should match the files shown here:</para>
-        <informalexample>
-            <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-jdbc-postgresql-0.9.6.jar
-postgresql-9.4-1201.jdbc41.jar</computeroutput>
-<prompt>$</prompt></screen>
-        </informalexample>
-        <para>Each of the <filename>.jar</filename> files above is either the authentication module
-            itself (<filename>guacamole-auth-jdbc-*-0.9.6.jar</filename>) or the corresponding JDBC
-            driver. <emphasis>If any of these files is missing, authentication will not
-                work!</emphasis></para>
+        <para>Only one of the directories within the archive will be applicable to you, depending on
+            whether you are using MariaDB, MySQL, or PostgreSQL.</para>
     </section>
     <section xml:id="jdbc-auth-database-creation">
-        <title>Creating the database</title>
+        <title>Creating the Guacamole database</title>
         <para>The database authentication module will need a database to store all authentication
             data and a user to use only for data access and manipulation. You could use an existing
             database and existing user, but for the sake of simplicity and security, these
             instructions assume you will be creating a new database and new user that will be used
             only by Guacamole and only for this authentication module.</para>
-        <para>At this point, you need either MySQL or PostgreSQL installed, and must have sufficient
-            access to create and administer databases. If this is not the case, install your
-            database of choice now. Most distributions will provide a convenient MySQL or PostgreSQL
-            package which will set up everything for you, including the root database user, if
+        <para>You need MariaDB, MySQL, or PostgreSQL installed, and must have sufficient access to
+            create and administer databases. If this is not the case, install your database of
+            choice now. Most distributions will provide a convenient MySQL or PostgreSQL package
+            which will set up everything for you, including the root database user, if
             applicable.</para>
         <para>For the sake of clarity, these instructions will refer to the database as
             "guacamole_db" and the user as "guacamole_user", but the database and user can be named
@@ -212,69 +210,186 @@ Type "help" for help.
                 databases exist.</para>
         </section>
     </section>
-    <section xml:id="jdbc-auth-configuration">
-        <title>Configuring Guacamole</title>
-        <para>Now that the database has been created, and all required SQL scripts have been run, we
-            need to add a few properties to <filename>guacamole.properties</filename> such that
-            Guacamole will load the appropriate authentication module and connect to the proper
-            database. These properties are specific to the database being used.</para>
-        <para>To use a MySQL database, you will need to specify the following:</para>
-        <informalexample>
-            <programlisting># Auth provider class
-auth-provider: net.sourceforge.guacamole.net.auth.mysql.MySQLAuthenticationProvider
-
-# MySQL properties
+    <section xml:id="jdbc-auth-installation">
+        <title>Installing database authentication</title>
+        <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
+            located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
+            the database authentication extension, you must:</para>
+        <orderedlist>
+            <listitem>
+                <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
+                    does not already exist.</para>
+            </listitem>
+            <listitem>
+                <para>Remove any existing authentication extensions from
+                        <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
+                    support using multiple authentication extensions at the same time.</para>
+            </listitem>
+            <listitem>
+                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.6.jar</filename>
+                    <emphasis>or</emphasis>
+                    <filename>guacamole-auth-jdbc-postgresql-0.9.6.jar</filename> within
+                        <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
+                    using MySQL/MariaDB or PostgreSQL.</para>
+            </listitem>
+            <listitem>
+                <para>Copy the JDBC driver for your database to
+                        <filename>GUACAMOLE_HOME/lib</filename>. Without a JDBC driver for your
+                    database, Guacamole will not be able to connect and authenticate users.</para>
+            </listitem>
+        </orderedlist>
+        <important>
+            <para>You will need to restart Guacamole by restarting your servlet container in order
+                to complete the installation. Doing this will disconnect all active users, so be
+                sure that it is safe to do so prior to attempting installation. If you do not
+                configure the database authentication properly, Guacamole will not start up again
+                until the configuration is fixed.</para>
+        </important>
+        <section xml:id="jdbc-auth-configuration">
+            <title>Configuring Guacamole for database authentication</title>
+            <para>Additional properties must be added to <filename>guacamole.properties</filename>
+                for Guacamole to properly connect to your database. These properties are specific to
+                the database being used, and must be set correctly for authentication to
+                work.</para>
+            <para>To use a MySQL database, you will need to specify the following:</para>
+            <informalexample>
+                <programlisting># MySQL properties
 mysql-hostname: localhost
 mysql-port: 3306
 mysql-database: <replaceable>guacamole_db</replaceable>
 mysql-username: <replaceable>guacamole_user</replaceable>
 mysql-password: <replaceable>some_password</replaceable></programlisting>
-            <para>For PostgreSQL the properties are similar, but with different prefixes:</para>
-            <informalexample>
-                <programlisting># Auth provider class
-auth-provider: org.glyptodon.guacamole.auth.postgresql.PostgreSQLAuthenticationProvider
-
-# MySQL properties
+                <para>For PostgreSQL the properties are similar, but with different prefixes:</para>
+                <informalexample>
+                    <programlisting># PostgreSQL properties
 postgresql-hostname: localhost
 postgresql-port: 5432
 postgresql-database: <replaceable>guacamole_db</replaceable>
 postgresql-username: <replaceable>guacamole_user</replaceable>
 postgresql-password: <replaceable>some_password</replaceable></programlisting>
+                </informalexample>
             </informalexample>
-        </informalexample>
-        <para>Be sure to specify the correct password for the MySQL or PostgreSQL user you created,
-            and specify the correct database and username if you didn't use "guacamole_db" and
-            "guacamole_user".</para>
-        <para>The database authentication module also provides configuration options to restrict
-            concurrent use of connections if desired:</para>
-        <informalexample>
-            <programlisting># MySQL
+            <para>These properties are relatively self-explanatory:</para>
+            <informaltable frame="all">
+                <tgroup cols="3">
+                    <colspec colname="c1" colnum="1" colwidth="1*"/>
+                    <colspec colname="c2" colnum="2" colwidth="1*"/>
+                    <colspec colname="c3" colnum="3" colwidth="2*"/>
+                    <thead>
+                        <row>
+                            <entry>MySQL/MariaDB Property</entry>
+                            <entry>PostgreSQL Property</entry>
+                            <entry>Description</entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row>
+                            <entry><property>mysql-hostname</property></entry>
+                            <entry><property>postgresql-hostname</property></entry>
+                            <entry>
+                                <para>The hostname or IP address of the server hosting your
+                                    database.</para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry><property>mysql-port</property></entry>
+                            <entry><property>postgresql-port</property></entry>
+                            <entry>
+                                <para>The port number of the database to connect to. For MySQL and
+                                    MariaDB, this will likely be 3306. For PostgreSQL, this will
+                                    likely be 5432.</para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry><property>mysql-database</property></entry>
+                            <entry><property>postgresql-database</property></entry>
+                            <entry>
+                                <para>The name of the database that you created for Guacamole. This
+                                    is given as "guacamole_db" in the examples given in this
+                                    chapter.</para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry><property>mysql-username</property></entry>
+                            <entry><property>postgresql-username</property></entry>
+                            <entry>
+                                <para>The username of the user that Guacamole should use to connect
+                                    to the database. This is given as "guacamole_user" in the
+                                    examples given in this chapter.</para>
+                            </entry>
+                        </row>
+                        <row>
+                            <entry><property>mysql-password</property></entry>
+                            <entry><property>postgresql-password</property></entry>
+                            <entry>
+                                <para>The password Guacamole should provide when authenticating with
+                                    the database. This is given as "some_password" in the examples
+                                    given in this chapter.</para>
+                            </entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </informaltable>
+            <para>Be sure to specify the correct password for the MySQL or PostgreSQL user you
+                created, and specify the correct database and username. Authentication will not work
+                if these parameters are not correct.</para>
+            <section xml:id="jdbc-auth-concurrency">
+                <title>Concurrent use of Guacamole connections</title>
+                <para>The database authentication module also provides configuration options to
+                    restrict concurrent use of connections if desired:</para>
+                <informalexample>
+                    <programlisting># MySQL
 mysql-disallow-simultaneous-connections: true
 
 # PostgreSQL
 postgresql-disallow-simultaneous-connections: true</programlisting>
-        </informalexample>
-        <para>This is not required, but with the above property in place, users attempting to use a
-            connection that is already in use by another user will be denied access. By default,
-            concurrent access is allowed. This does not affect balancing groups, but does affect the
-            usage of connections within balancing groups.</para>
-        <para>Concurrent access to balancing groups is restricted by default, and while balancing
-            groups can be used by any number of users simultaneously, each individual user may only
-            have one active connection to a balancing group. You can change this if you wish, but
-            beware that individual users will then be able to exhaust the available connections of a
-            balancing group:</para>
-        <informalexample>
-            <programlisting># MySQL
+                </informalexample>
+                <para>This is not required, but with the above property in place, users attempting
+                    to use a connection that is already in use by another user will be denied
+                    access. By default, concurrent access is allowed. This does not affect balancing
+                    groups, but does affect the usage of connections within balancing groups.</para>
+                <para>Concurrent access to balancing groups is restricted by default, and while
+                    balancing groups can be used by any number of users simultaneously, each
+                    individual user may only have one active connection to a balancing group. You
+                    can change this if you wish, but beware that individual users will then be able
+                    to exhaust the available connections of a balancing group:</para>
+                <informalexample>
+                    <programlisting># MySQL
 mysql-disallow-duplicate-connections: false
 
 # PostgreSQL
 postgresql-disallow-duplicate-connections: false</programlisting>
-        </informalexample>
-        <para>Once you have <filename>guacamole.properties</filename> modified appropriately,
-            restart Tomcat (or whatever servlet container you are using) and Guacamole will use your
-            database for authentication. Be sure to watch the logs in case something is wrong with
-            the configuration, and remember that, for security reasons, Guacamole will always report
-            authentication errors as "invalid login" regardless of the true cause.</para>
+                </informalexample>
+                <para>Once you have <filename>guacamole.properties</filename> modified
+                    appropriately, restart Tomcat (or whatever servlet container you are using) and
+                    Guacamole will use your database for authentication. Be sure to watch the logs
+                    in case something is wrong with the configuration, and remember that, for
+                    security reasons, Guacamole will always report authentication errors as "invalid
+                    login" regardless of the true cause.</para>
+            </section>
+        </section>
+        <section>
+            <title>Completing the installation</title>
+            <para>Guacamole will only reread <filename>guacamole.properties</filename> and load
+                newly-installed extensions during startup, so your servlet container will need to be
+                restarted before the database authentication will take effect. Restart your servlet
+                container and give the new authentication a try.</para>
+            <para>
+                <important>
+                    <para>You only need to restart your servlet container. <emphasis>You do not need
+                            to restart <package>guacd</package></emphasis>.</para>
+                    <para><package>guacd</package> is completely independent of the web application
+                        and does not deal with <filename>guacamole.properties</filename> or the
+                        authentication system in any way. Since you are already restarting the
+                        servlet container, restarting <package>guacd</package> as well technically
+                        won't hurt anything, but doing so is completely pointless.</para>
+                </important>
+            </para>
+            <para>If Guacamole does not come back online after restarting your servlet container,
+                check the logs. Problems in the configuration of the database authentication
+                extension will prevent Guacamole from starting up, and any such errors will be
+                recorded in the logs of your servlet container.</para>
+        </section>
     </section>
     <section xml:id="jdbc-auth-default-user">
         <title>Logging in</title>
@@ -282,12 +397,13 @@ postgresql-disallow-duplicate-connections: false</programlisting>
             <primary>default user</primary>
         </indexterm>
         <indexterm>
-            <primary>guacadmin</primary>
+            <primary><systemitem>guacadmin</systemitem></primary>
         </indexterm>
         <para>The default Guacamole user created by the provided SQL scripts is
-                "<token>guacadmin</token>", with a default password of "<token>guacadmin</token>".
-            Once you have the database authentication working, you should change your password
-            immediately by editing your own user in the administration screen.</para>
+                "<systemitem>guacadmin</systemitem>", with a default password of
+                "<systemitem>guacadmin</systemitem>". Once you have verified that the database
+            authentication is working, <emphasis>you should change your password
+                immediately</emphasis>.</para>
         <para>More detailed instructions for managing users and connections is given in <xref
                 linkend="administration"/>.</para>
     </section>
@@ -426,8 +542,9 @@ INSERT INTO guacamole_user (username, password_salt, password_hash)
                     <term><property>protocol</property></term>
                     <listitem>
                         <para>The protocol to use with this connection. This is the name of the
-                            protocol that should be sent to guacd when connecting, for example "vnc"
-                            or "rdp".</para>
+                            protocol that should be sent to <package>guacd</package> when
+                            connecting, for example "<constant>vnc</constant>" or
+                                "<constant>rdp</constant>".</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -237,6 +237,9 @@ Type "help" for help.
                         <filename>GUACAMOLE_HOME/lib</filename>. Without a JDBC driver for your
                     database, Guacamole will not be able to connect and authenticate users.</para>
             </listitem>
+            <listitem>
+                <para>Configure Guacamole to use database authentication, as described below.</para>
+            </listitem>
         </orderedlist>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -13,7 +13,7 @@
         <primary>load balancing</primary>
     </indexterm>
     <para>Guacamole supports authentication via MySQL or PostgreSQL databases through extensions
-        available from the project website. These extensions allows users and connections to be
+        available from the project website. These extensions allow users and connections to be
         managed from within the web application. Unlike the default, XML-driven authentication
         module, all changes to users and connections take effect immediately; users need not logout
         and back in to see new connections.</para>
@@ -54,26 +54,38 @@
             <varlistentry>
                 <term><filename>mysql/</filename></term>
                 <listitem>
-                    <para>Contains the MySQL/MariaDB authentication extension as a self-contained
-                            <filename>.jar</filename> file, along with a
-                            <filename>schema/</filename> directory containing the SQL scripts
-                        required to set up the database.</para>
-                    <para><emphasis>The MySQL JDBC connector is not included.</emphasis> You must
-                        obtain the JDBC connector <filename>.jar</filename> from within the
-                        "Connector/J" archive downloadable from <link
+                    <para>Contains the MySQL/MariaDB authentication extension,
+                            <filename>guacamole-auth-jdbc-mysql-0.9.6.jar</filename>, along with a
+                            <filename>schema/</filename> directory containing MySQL-specific SQL
+                        scripts required to set up the database. The
+                            <filename>guacamole-auth-jdbc-mysql-0.9.6.jar</filename> file will
+                        ultimately need to be placed within
+                            <filename>GUACAMOLE_HOME/extensions</filename>, while the MySQL JDBC
+                        driver must be placed within <filename>GUACAMOLE_HOME/lib</filename>.</para>
+                    <para><emphasis>The MySQL JDBC driver is not included with the
+                            extension.</emphasis> You must obtain the JDBC driver
+                            <filename>.jar</filename> yourself from <link
                             xlink:href="http://dev.mysql.com/downloads/connector/j/">MySQL's
-                            website</link>.</para>
+                            website</link>. The driver is known as "Connector/J", and the required
+                            <filename>.jar</filename> will be within a <filename>.tar.gz</filename>
+                        archive.</para>
                 </listitem>
             </varlistentry>
             <varlistentry>
                 <term><filename>postgresql/</filename></term>
                 <listitem>
-                    <para>Contains the PostgreSQL authentication extension as a self-contained
-                            <filename>.jar</filename> file, along with a
-                            <filename>schema/</filename> directory containing the SQL scripts
-                        required to set up the database.</para>
-                    <para><emphasis>The PostgreSQL JDBC driver is not included.</emphasis> You must
-                        obtain the JDBC driver <filename>.jar</filename> from <link
+                    <para>Contains the PostgreSQL authentication extension,
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.6.jar</filename>, along
+                        with a <filename>schema/</filename> directory containing PostgreSQL-specific
+                        SQL scripts required to set up the database. The
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.6.jar</filename> file will
+                        ultimately need to be placed within
+                            <filename>GUACAMOLE_HOME/extensions</filename>, while the PostgreSQL
+                        JDBC driver must be placed within
+                        <filename>GUACAMOLE_HOME/lib</filename>.</para>
+                    <para><emphasis>The PostgreSQL JDBC driver is not included with the
+                            extension.</emphasis> You must obtain the JDBC driver
+                            <filename>.jar</filename> yourself from <link
                             xlink:href="https://jdbc.postgresql.org/download.html#current"
                             >PostgreSQL's website</link>. The proper <filename>.jar</filename> file
                         depends on the version of Java you have installed. </para>
@@ -86,7 +98,7 @@
     <section xml:id="jdbc-auth-database-creation">
         <title>Creating the Guacamole database</title>
         <para>The database authentication module will need a database to store all authentication
-            data and a user to use only for data access and manipulation. You could use an existing
+            data and a user to use only for data access and manipulation. You can use an existing
             database and existing user, but for the sake of simplicity and security, these
             instructions assume you will be creating a new database and new user that will be used
             only by Guacamole and only for this authentication module.</para>
@@ -262,7 +274,8 @@ mysql-port: 3306
 mysql-database: <replaceable>guacamole_db</replaceable>
 mysql-username: <replaceable>guacamole_user</replaceable>
 mysql-password: <replaceable>some_password</replaceable></programlisting>
-                <para>For PostgreSQL the properties are similar, but with different prefixes:</para>
+                <para>For PostgreSQL, the properties are similar, but with different
+                    prefixes:</para>
                 <informalexample>
                     <programlisting># PostgreSQL properties
 postgresql-hostname: localhost
@@ -272,7 +285,10 @@ postgresql-username: <replaceable>guacamole_user</replaceable>
 postgresql-password: <replaceable>some_password</replaceable></programlisting>
                 </informalexample>
             </informalexample>
-            <para>These properties are relatively self-explanatory:</para>
+            <para>The properties absolutely required by the database authentication extension are
+                relatively few and self-explanatory, describing only how the connection to the
+                database is to be established, and how Guacamole will authenticate when querying the
+                database:</para>
             <informaltable frame="all">
                 <tgroup cols="3">
                     <colspec colname="c1" colnum="1" colwidth="1*"/>
@@ -333,9 +349,9 @@ postgresql-password: <replaceable>some_password</replaceable></programlisting>
                     </tbody>
                 </tgroup>
             </informaltable>
-            <para>Be sure to specify the correct password for the MySQL or PostgreSQL user you
-                created, and specify the correct database and username. Authentication will not work
-                if these parameters are not correct.</para>
+            <para>Be sure to specify the correct username and password for the database user you
+                created, and to specify the correct database. Authentication will not work if these
+                parameters are not correct.</para>
             <section xml:id="jdbc-auth-concurrency">
                 <title>Concurrent use of Guacamole connections</title>
                 <para>The database authentication module also provides configuration options to
@@ -363,12 +379,6 @@ mysql-disallow-duplicate-connections: false
 # PostgreSQL
 postgresql-disallow-duplicate-connections: false</programlisting>
                 </informalexample>
-                <para>Once you have <filename>guacamole.properties</filename> modified
-                    appropriately, restart Tomcat (or whatever servlet container you are using) and
-                    Guacamole will use your database for authentication. Be sure to watch the logs
-                    in case something is wrong with the configuration, and remember that, for
-                    security reasons, Guacamole will always report authentication errors as "invalid
-                    login" regardless of the true cause.</para>
             </section>
         </section>
         <section>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -186,6 +186,9 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                 <para>Copy <filename>guacamole-auth-ldap-0.9.6.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </listitem>
+            <listitem>
+                <para>Configure Guacamole to use LDAP authentication, as described below.</para>
+            </listitem>
         </orderedlist>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -1,47 +1,194 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <chapter xml:id="ldap-auth" xmlns="http://docbook.org/ns/docbook" version="5.0" xml:lang="en"
-    xmlns:xi="http://www.w3.org/2001/XInclude">
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>LDAP authentication</title>
     <indexterm>
         <primary>LDAP</primary>
     </indexterm>
     <para>Guacamole supports LDAP authentication via an extension available from the main project
         website. This extension allows users and connections to be stored directly within an LDAP
-        directory.</para>
-    <para>The LDAP authentication module will need an LDAP directory as storage for all
-        authentication data, and the instructions here assume you already have an LDAP directory
-        installed and working. The schema-related directions are further specific to the OpenLDAP
-        implementation of LDAP. Other LDAP implementations will have their own methods for updating
-        the schema. For such situations, a standards-compliant file describing the schema required
-        by Guacamole's LDAP support is included.</para>
-    <section xml:id="installing-ldap-auth">
-        <title>Installing LDAP authentication</title>
-        <para>The LDAP authentication module is not included in the main Guacamole bundle nor is it
-            enabled by default. You must use the download link provided in the downloads section of
-            the main Guacamole site.</para>
-        <para>The downloaded <filename>.tar.gz</filename> file will contain several
-            directories:</para>
+        directory. If you have a centralized authentication system that uses LDAP, Guacamole's LDAP
+        support can be a good way to allow your users to use their existing usernames and passwords
+        to log into Guacamole.</para>
+    <para>To use the LDAP authentication extension, you will need:</para>
+    <orderedlist>
+        <listitem>
+            <para>An LDAP directory as storage for all authentication data, such as OpenLDAP.</para>
+        </listitem>
+        <listitem>
+            <para>The ability to modify the schema of your LDAP directory.</para>
+        </listitem>
+    </orderedlist>
+    <para>The instructions here assume you already have an LDAP directory installed and working, and
+        do not cover the initial setup of such a directory.</para>
+    <important>
+        <para>This chapter deals with the contents of <varname>GUACAMOLE_HOME</varname> - the
+            Guacamole configuration directory. For the sake of example,
+                <filename>/usr/share/tomcat/.guacamole</filename> will be used as
+                <varname>GUACAMOLE_HOME</varname> because:</para>
+        <orderedlist>
+            <listitem>
+                <para>It is very common to run Guacamole under Tomcat.</para>
+            </listitem>
+            <listitem>
+                <para>A common location for the Tomcat user's home directory is
+                        <filename>/usr/share/tomcat</filename>.</para>
+            </listitem>
+            <listitem>
+                <para>By default, when searching for <varname>GUACAMOLE_HOME</varname>, Guacamole
+                    will look for <filename>.guacamole</filename> within the user's home
+                    directory.</para>
+            </listitem>
+        </orderedlist>
+        <para><filename>/usr/share/tomcat/.guacamole</filename> is thus highly likely to be the same
+            as, if not similar to, your system's default <varname>GUACAMOLE_HOME</varname>. If your
+            system differs, or you are not using Tomcat, you will need to determine or set the
+            location of <varname>GUACAMOLE_HOME</varname> before proceeding. See <xref
+                linkend="configuring-guacamole"/> for more information on locating or setting
+                <varname>GUACAMOLE_HOME</varname>.</para>
+    </important>
+    <section>
+        <title>How Guacamole uses LDAP</title>
+        <para>If the LDAP extension is installed, Guacamole will authenticate users against your
+            LDAP server by attempting a bind as that user. The given username and password will be
+            submitted to the LDAP server during the bind attempt.</para>
+        <para>If the bind attempt is successful, the set of available Guacamole connections is
+            queried from the LDAP directory by executing an LDAP query as the bound user. Each
+            Guacamole connection is represented within the directory as a special type of group:
+                <classname>guacConfigGroup</classname>. Attributes associated with the group define
+            the protocol and parameters of the connection, and users are allowed access to the
+            connection only if they are members of that group.</para>
+        <para>This architecture has a number of benefits:</para>
+        <orderedlist>
+            <listitem>
+                <para>Your users can use their existing usernames and passwords to log into
+                    Guacamole.</para>
+            </listitem>
+            <listitem>
+                <para>You can manage Guacamole connections using the same tool that you already use
+                    to manage your LDAP directory, such as <link
+                        xlink:href="https://directory.apache.org/studio/">Apache Directory
+                        Studio</link>.</para>
+            </listitem>
+            <listitem>
+                <para>Existing security restrictions can limit visibility/accessibility of Guacamole
+                    connections.</para>
+            </listitem>
+            <listitem>
+                <para>Access to connections can easily be granted and revoked, as each connection is
+                    represented by a group.</para>
+            </listitem>
+        </orderedlist>
+    </section>
+    <section>
+        <title>Downloading the LDAP extension</title>
+        <para>The LDAP authentication extension is available separately from the main
+                <filename>guacamole.war</filename>. The link for this and all other
+            officially-supported and compatible extensions for a particular version of Guacamole are
+            provided on the release notes for that version. You can find the release notes for
+            current versions of Guacamole here: <link xlink:href="http://guac-dev.org/releases/"
+            >http://guac-dev.org/releases/</link>.</para>
+        <para>The LDAP authentication extension is packaged as a <filename>.tar.gz</filename> file
+            containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>lib/</filename></term>
+                <term><filename>guacamole-auth-ldap-0.9.6.jar</filename></term>
                 <listitem>
-                    <para>Contains all <filename>.jar</filename> files required for the LDAP
-                        authentication module to work, including the module itself and the LDAP
-                        library driving it.</para>
+                    <para>The Guacamole LDAP support extension itself, which must be placed in
+                            <filename>GUACAMOLE_HOME/extensions</filename>.</para>
                 </listitem>
             </varlistentry>
             <varlistentry>
                 <term><filename>schema/</filename></term>
                 <listitem>
-                    <para>Contains an <filename>.ldif</filename> file which describes the LDAP
-                        schema changes as required for an OpenLDAP server, as well as a
-                            <filename>.schema</filename> file compliant with RFC-2252. The
-                            <filename>.schema</filename> file can be transformed into the
-                            <filename>.ldif</filename> file automatically.</para>
+                    <para>LDAP schema files. An <filename>.ldif</filename> file compatible with
+                        OpenLDAP is provided, as well as a <filename>.schema</filename> file
+                        compliant with RFC-2252. The <filename>.schema</filename> file can be
+                        transformed into the <filename>.ldif</filename> file automatically.</para>
                 </listitem>
             </varlistentry>
         </variablelist>
+    </section>
+    <section>
+        <title>Preparing your LDAP directory</title>
+        <para>Although your LDAP directory already provides a means of storing and authenticating
+            users, Guacamole also needs storage of connection configuration data, such as hostnames
+            and ports, and a means of associating users with connections that they should have
+            access to.</para>
+        <para>This need for additional connection storage means that the LDAP directory schema must
+            be modified. An additional object, <classname>guacConfigGroup</classname>, contains all
+            configuration information for a particular connection, and can be associated with
+            arbitrarily-many users. Only users which are members of a connection's group will have
+            access to that connection.</para>
+        <para>The necessary modifications to the LDAP schema are made through applying one of the
+            provided schema files. <emphasis>This must be done before Guacamole can be used with
+                LDAP</emphasis>.</para>
+        <important>
+            <para>The instructions given for applying the Guacamole LDAP schema changes are specific
+                to OpenLDAP, but other LDAP implementations, including ActiveDirectory, will have
+                their own methods for updating the schema.</para>
+            <para>If you are not using OpenLDAP, a standards-compliant schema file is provided that
+                can be used to update the schema of any LDAP directory supporting RFC-2252. Please
+                consult the documentation of your LDAP directory to determine how such schema
+                changes can be applied.</para>
+        </important>
+        <para>The schema files are located within the <filename>schema/</filename> directory of the
+            archive containing the LDAP extension. You will only need one of these files:</para>
+        <variablelist>
+            <varlistentry>
+                <term><filename>guacConfigGroup.schema</filename></term>
+                <listitem>
+                    <para>A standards-compliant file describing the schema. This file can be used
+                        with any LDAP directory compliant with RFC-2252.</para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><filename>guacConfigGroup.ldif</filename></term>
+                <listitem>
+                    <para>An LDIF file compatible with OpenLDAP. This file was automatically built
+                        from the provided <filename>.schema</filename> file for convenience.</para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+        <para>This chapter will cover applying <filename>guacConfigGroup.ldif</filename> to an
+            OpenLDAP server. If you are not using OpenLDAP, your LDAP server should provide
+            documentation for modifying its schema. If this is the case, please consult the
+            documentation of your LDAP server before proceeding.</para>
+        <section>
+            <title>Applying the schema changes to OpenLDAP</title>
+            <para>Schema changes to OpenLDAP are applied using the <command>ldapadd</command>
+                utility with the provided <filename>guacConfigGroup.ldif</filename> file:</para>
+            <informalexample>
+                <screen><prompt>#</prompt> <userinput>ldapadd -Q -Y EXTERNAL -H ldapi:/// -f schema/guacConfigGroup.ldif</userinput>
+<computeroutput>adding new entry "cn=guacConfigGroup,cn=schema,cn=config"
+</computeroutput>
+<prompt>#</prompt></screen>
+            </informalexample>
+            <para>If the <classname>guacConfigGroup</classname> object was added successfully, you
+                should see output as above. You can confirm the presence of the new object class
+                using <command>ldapsearch</command>:</para>
+            <informalexample>
+                <screen><prompt>#</prompt> <userinput>ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=schema,cn=config dn</userinput>
+<computeroutput>dn: cn=schema,cn=config
+
+dn: cn={0}core,cn=schema,cn=config
+
+dn: cn={1}cosine,cn=schema,cn=config
+
+dn: cn={2}nis,cn=schema,cn=config
+
+dn: cn={3}inetorgperson,cn=schema,cn=config
+
+dn: cn={4}guacConfigGroup,cn=schema,cn=config
+</computeroutput>
+<prompt>#</prompt></screen>
+            </informalexample>
+        </section>
+    </section>
+    <section xml:id="installing-ldap-auth">
+        <title>Installing LDAP authentication</title>
         <para>The contents of <filename>lib/</filename> must be copied into the classpath of
             Guacamole, which is the directory specified by the <property>lib-directory</property>
             property in <filename>guacamole.properties</filename>. If this property is not
@@ -49,17 +196,17 @@
                 <filename>/var/lib/guacamole/classpath</filename> is a good choice, but it can be
             whatever you like.</para>
         <para>After copying the files in place, check to make sure all files are present, and there
-            are no conflicts in between multiple versions of <package>guacamole-auth-ldap</package>.
-            The contents should match at least the files shown here:</para>
-        <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-ldap-0.9.6.jar  jldap-4.3.jar</computeroutput>
-<prompt>$</prompt></screen>
-        <para>Each of the <filename>.jar</filename> files above is either the LDAP authentication
-            module itself (<filename>guacamole-auth-ldap-0.9.6.jar</filename>) or a dependency. They
-            must all be placed in Guacamole's <property>lib-directory</property> for the LDAP
-            authentication to work.</para>
+            are no conflicts in between multiple versions of
+            <package>guacamole-auth-ldap</package>.</para>
+        <important>
+            <para>You will need to restart Guacamole by restarting your servlet container in order
+                to complete the installation. Doing this will disconnect all active users, so be
+                sure that it is safe to do so prior to attempting installation. If you do not
+                configure the LDAP authentication properly, Guacamole will not start up again until
+                the configuration is fixed.</para>
+        </important>
         <section>
-            <title>Configuring Guacamole</title>
+            <title>Configuring Guacamole for LDAP</title>
             <indexterm>
                 <primary>configuring LDAP</primary>
             </indexterm>
@@ -70,10 +217,7 @@
             <para>Additional properties must be added to <filename>guacamole.properties</filename>
                 for Guacamole to load the LDAP support and for the LDAP support to properly connect
                 to your LDAP server:</para>
-            <programlisting># Auth provider class
-auth-provider: net.sourceforge.guacamole.net.auth.ldap.LDAPAuthenticationProvider
-
-# LDAP properties
+            <programlisting># LDAP properties
 ldap-hostname:           <replaceable>localhost</replaceable>
 ldap-port:               <replaceable>389</replaceable>
 ldap-user-base-dn:       <replaceable>ou=people,dc=example,dc=net</replaceable>
@@ -137,49 +281,31 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
                 after you restart Tomcat (or whatever servlet container you are using). You will
                 still need to install the schema modifications to your LDAP server such that you can
                 create new configurations and associated them with users.</para>
-        </section>
-        <section>
-            <title>Installing the schema</title>
-            <para>Guacamole's LDAP support requires modifications to the standard LDAP schema, adding
-                support for an additional object called <classname>guacConfigGroup</classname>. This
-                object and its use will be explained in more detail later. For now, we must add
-                support for this object to the LDAP directory through the provided schema
-                file.</para>
-            <para>The <filename>schema/</filename> directory contains two files:
-                    <filename>guacConfigGroup.schema</filename>, a standards-compliant file
-                describing the schema, and <filename>guacConfigGroup.ldif</filename>, an LDIF file
-                which was automatically generated from the <filename>.schema</filename> file
-                specifically for update the schema of an OpenLDAP server. We will be working with
-                    <filename>guacConfigGroup.ldif</filename>. If you are not using OpenLDAP, your
-                LDAP server should provide documentation for modifying its schema.</para>
-            <para>The <classname>guacConfigGroup</classname> object can be created using the
-                    <command>ldapadd</command> utility and the provided <filename>.ldif</filename>
-                file:</para>
-            <informalexample>
-                <screen><prompt>#</prompt> <userinput>ldapadd -Q -Y EXTERNAL -H ldapi:/// -f schema/guacConfigGroup.ldif</userinput>
-<computeroutput>adding new entry "cn=guacConfigGroup,cn=schema,cn=config"
-</computeroutput>
-<prompt>#</prompt></screen>
-            </informalexample>
-            <para>If the <classname>guacConfigGroup</classname> object was added successfully, you
-                should see output as above. You can confirm the presence of the new object class
-                using the <command>ldapsearch</command> utility:</para>
-            <informalexample>
-                <screen><prompt>#</prompt> <userinput>ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=schema,cn=config dn</userinput>
-<computeroutput>dn: cn=schema,cn=config
-
-dn: cn={0}core,cn=schema,cn=config
-
-dn: cn={1}cosine,cn=schema,cn=config
-
-dn: cn={2}nis,cn=schema,cn=config
-
-dn: cn={3}inetorgperson,cn=schema,cn=config
-
-dn: cn={4}guacConfigGroup,cn=schema,cn=config
-</computeroutput>
-<prompt>#</prompt></screen>
-            </informalexample>
+            <section>
+                <title>Completing the installation</title>
+                <para>Guacamole will only reread <filename>guacamole.properties</filename> and load
+                    newly-installed extensions during startup, so your servlet container will need
+                    to be restarted before the LDAP authentication will take effect. Restart your
+                    servlet container and give the new authentication a try.</para>
+                <para>
+                    <important>
+                        <para>You only need to restart your servlet container. <emphasis>You do not
+                                need to restart <package>guacd</package></emphasis>.</para>
+                        <para><package>guacd</package> is completely independent of the web
+                            application and does not deal with
+                                <filename>guacamole.properties</filename> or the authentication
+                            system in any way. Since you are already restarting the servlet
+                            container, restarting <package>guacd</package> as well technically won't
+                            hurt anything, but doing so is completely pointless.</para>
+                    </important>
+                </para>
+                <para>If Guacamole does not come back online after restarting your servlet
+                    container, check the logs. Problems in the configuration of the LDAP extension
+                    will prevent Guacamole from starting up, and any such errors will be recorded in
+                    the logs of your servlet container. If properly configured, you will be able to
+                    log in as any user within the defined
+                    <property>ldap-user-base-dn</property>.</para>
+            </section>
         </section>
     </section>
     <section xml:id="ldap-auth-schema">
@@ -237,7 +363,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     </listitem>
                 </varlistentry>
             </variablelist>
-            <para>For example, to create a new VNC connection which connects to localhost at port
+            <para>For example, to create a new VNC connection which connects to "localhost" at port
                 5900, while granting access to <systemitem>user1</systemitem> and
                     <systemitem>user2</systemitem>, you could create an <filename>.ldif</filename>
                 file like the following:</para>
@@ -268,8 +394,9 @@ adding new entry "cn=Example Connection,ou=groups,dc=example,dc=net"
                     <filename>.ldif</filename> file you just created.</para>
             <para>There is, of course, no need to use only the standard LDAP utilities to create
                 connections and users. There are useful graphical environments for manipulating LDAP
-                directories, such as Apache Directory Studio, which make many of the tasks given
-                above much easier.</para>
+                directories, such as <link xlink:href="https://directory.apache.org/studio/">Apache
+                    Directory Studio</link>, which make many of the tasks given above much
+                easier.</para>
         </section>
     </section>
 </chapter>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -24,30 +24,10 @@
     <para>The instructions here assume you already have an LDAP directory installed and working, and
         do not cover the initial setup of such a directory.</para>
     <important>
-        <para>This chapter deals with the contents of <varname>GUACAMOLE_HOME</varname> - the
-            Guacamole configuration directory. For the sake of example,
-                <filename>/usr/share/tomcat/.guacamole</filename> will be used as
-                <varname>GUACAMOLE_HOME</varname> because:</para>
-        <orderedlist>
-            <listitem>
-                <para>It is very common to run Guacamole under Tomcat.</para>
-            </listitem>
-            <listitem>
-                <para>A common location for the Tomcat user's home directory is
-                        <filename>/usr/share/tomcat</filename>.</para>
-            </listitem>
-            <listitem>
-                <para>By default, when searching for <varname>GUACAMOLE_HOME</varname>, Guacamole
-                    will look for <filename>.guacamole</filename> within the user's home
-                    directory.</para>
-            </listitem>
-        </orderedlist>
-        <para><filename>/usr/share/tomcat/.guacamole</filename> is thus highly likely to be the same
-            as, if not similar to, your system's default <varname>GUACAMOLE_HOME</varname>. If your
-            system differs, or you are not using Tomcat, you will need to determine or set the
-            location of <varname>GUACAMOLE_HOME</varname> before proceeding. See <xref
-                linkend="configuring-guacamole"/> for more information on locating or setting
-                <varname>GUACAMOLE_HOME</varname>.</para>
+        <para>This chapter involves modifying the contents of <varname>GUACAMOLE_HOME</varname> -
+            the Guacamole configuration directory. If you are unsure where
+                <varname>GUACAMOLE_HOME</varname> is located on your system, please consult <xref
+                linkend="configuring-guacamole"/> before proceeding.</para>
     </important>
     <section>
         <title>How Guacamole uses LDAP</title>
@@ -127,7 +107,7 @@
                 LDAP</emphasis>.</para>
         <important>
             <para>The instructions given for applying the Guacamole LDAP schema changes are specific
-                to OpenLDAP, but other LDAP implementations, including ActiveDirectory, will have
+                to OpenLDAP, but other LDAP implementations, including Active Directory, will have
                 their own methods for updating the schema.</para>
             <para>If you are not using OpenLDAP, a standards-compliant schema file is provided that
                 can be used to update the schema of any LDAP directory supporting RFC-2252. Please
@@ -189,15 +169,24 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
     </section>
     <section xml:id="installing-ldap-auth">
         <title>Installing LDAP authentication</title>
-        <para>The contents of <filename>lib/</filename> must be copied into the classpath of
-            Guacamole, which is the directory specified by the <property>lib-directory</property>
-            property in <filename>guacamole.properties</filename>. If this property is not
-            specified, simply add it. On Linux servers,
-                <filename>/var/lib/guacamole/classpath</filename> is a good choice, but it can be
-            whatever you like.</para>
-        <para>After copying the files in place, check to make sure all files are present, and there
-            are no conflicts in between multiple versions of
-            <package>guacamole-auth-ldap</package>.</para>
+        <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
+            located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
+            the LDAP authentication extension, you must:</para>
+        <orderedlist>
+            <listitem>
+                <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
+                    does not already exist.</para>
+            </listitem>
+            <listitem>
+                <para>Remove any existing authentication extensions from
+                        <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
+                    support using multiple authentication extensions at the same time.</para>
+            </listitem>
+            <listitem>
+                <para>Copy <filename>guacamole-auth-ldap-0.9.6.jar</filename> within
+                        <filename>GUACAMOLE_HOME/extensions</filename>.</para>
+            </listitem>
+        </orderedlist>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order
                 to complete the installation. Doing this will disconnect all active users, so be
@@ -223,23 +212,24 @@ ldap-port:               <replaceable>389</replaceable>
 ldap-user-base-dn:       <replaceable>ou=people,dc=example,dc=net</replaceable>
 ldap-username-attribute: <replaceable>uid</replaceable>
 ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable></programlisting>
-            <para>The LDAP support depends on the following properties, as shown in the example
-                above:</para>
+            <para>To use Guacamole's LDAP support, you must specify each of the following
+                properties, as shown in the example above:</para>
             <variablelist>
                 <varlistentry>
                     <term><property>ldap-hostname</property></term>
                     <listitem>
                         <para>The hostname of your LDAP server. In the example above, this is given
-                            as "localhost" - the same machine as the web server hosting Guacamole,
-                            but this can be anything.</para>
+                            as "localhost" - the same machine as the web server hosting Guacamole.
+                            You will need to use a different value if your LDAP server is located
+                            elsewhere.</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><property>ldap-port</property></term>
                     <listitem>
-                        <para>The port your LDAP server listens on. Unless you altered the
-                            configuration somehow, your LDAP server probably listens on the standard
-                            port of 389.</para>
+                        <para>The port your LDAP server listens on. The example above uses the
+                            standard port 389. Unless you manually configured your LDAP server to do
+                            otherwise, your LDAP server probably listens on port 389 as well.</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>
@@ -252,16 +242,17 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
                 <varlistentry>
                     <term><property>ldap-username-attribute</property></term>
                     <listitem>
-                        <para>The attribute which contains the username which is part of the DN for
-                            all Guacamole users. Usually, this is <property>uid</property>. This
-                            works together with the user base DN to determine the full DN of each
-                            user logging in.</para>
-                        <para>For example, if the base DN is
-                                "<systemitem>ou=people,dc=example,dc=net</systemitem>" (like the
-                            example above) and the username attribute is "<property>uid</property>",
-                            then a person attempting to login as "<systemitem>user</systemitem>"
-                            would effectively bind with the LDAP directory as
-                                "<systemitem>uid=user,ou=people,dc=example,dc=net</systemitem>".</para>
+                        <para>The attribute which contains the username and which is part of the DN
+                            for all Guacamole users. Usually, this will be
+                            "<property>uid</property>". This is used together with the user base DN
+                            to derive the full DN of each user logging in.</para>
+                        <para>For example, if <property>ldap-user-base-dn</property> is
+                                "<systemitem>ou=people,dc=example,dc=net</systemitem>", as in the
+                            example above, and <property>ldap-username-attribute</property> is
+                                "<property>uid</property>", then a person attempting to login as
+                                "<systemitem>user</systemitem>" would be mapped to the following
+                            full DN:
+                            "<systemitem>uid=user,ou=people,dc=example,dc=net</systemitem>".</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>
@@ -269,43 +260,37 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
                     <listitem>
                         <para>The base of the DN for all Guacamole configurations. Each
                             configuration is analogous to a connection. Within Guacamole's LDAP
-                            support, each configuration functions as a group, having user members. A
-                            user which is a member of a particular configuration group will have
-                            access to that configuration.</para>
-                        <para>This base DN will be used when querying all configurations accessible
+                            support, each configuration functions as a group, having user members,
+                            where each member of a particular configuration group will have access
+                            to that configuration.</para>
+                        <para>This base DN will be used when querying the configurations accessible
                             by a user once they have successfully logged in.</para>
                     </listitem>
                 </varlistentry>
             </variablelist>
-            <para>With the above properties properly set, Guacamole will connect to your LDAP server
-                after you restart Tomcat (or whatever servlet container you are using). You will
-                still need to install the schema modifications to your LDAP server such that you can
-                create new configurations and associated them with users.</para>
-            <section>
-                <title>Completing the installation</title>
-                <para>Guacamole will only reread <filename>guacamole.properties</filename> and load
-                    newly-installed extensions during startup, so your servlet container will need
-                    to be restarted before the LDAP authentication will take effect. Restart your
-                    servlet container and give the new authentication a try.</para>
-                <para>
-                    <important>
-                        <para>You only need to restart your servlet container. <emphasis>You do not
-                                need to restart <package>guacd</package></emphasis>.</para>
-                        <para><package>guacd</package> is completely independent of the web
-                            application and does not deal with
-                                <filename>guacamole.properties</filename> or the authentication
-                            system in any way. Since you are already restarting the servlet
-                            container, restarting <package>guacd</package> as well technically won't
-                            hurt anything, but doing so is completely pointless.</para>
-                    </important>
-                </para>
-                <para>If Guacamole does not come back online after restarting your servlet
-                    container, check the logs. Problems in the configuration of the LDAP extension
-                    will prevent Guacamole from starting up, and any such errors will be recorded in
-                    the logs of your servlet container. If properly configured, you will be able to
-                    log in as any user within the defined
-                    <property>ldap-user-base-dn</property>.</para>
-            </section>
+        </section>
+        <section>
+            <title>Completing the installation</title>
+            <para>Guacamole will only reread <filename>guacamole.properties</filename> and load
+                newly-installed extensions during startup, so your servlet container will need to be
+                restarted before the LDAP authentication will take effect. Restart your servlet
+                container and give the new authentication a try.</para>
+            <para>
+                <important>
+                    <para>You only need to restart your servlet container. <emphasis>You do not need
+                            to restart <package>guacd</package></emphasis>.</para>
+                    <para><package>guacd</package> is completely independent of the web application
+                        and does not deal with <filename>guacamole.properties</filename> or the
+                        authentication system in any way. Since you are already restarting the
+                        servlet container, restarting <package>guacd</package> as well technically
+                        won't hurt anything, but doing so is completely pointless.</para>
+                </important>
+            </para>
+            <para>If Guacamole does not come back online after restarting your servlet container,
+                check the logs. Problems in the configuration of the LDAP extension will prevent
+                Guacamole from starting up, and any such errors will be recorded in the logs of your
+                servlet container. If properly configured, you will be able to log in as any user
+                within the defined <property>ldap-user-base-dn</property>.</para>
         </section>
     </section>
     <section xml:id="ldap-auth-schema">
@@ -331,11 +316,10 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
         <section>
             <title>Connections and parameters</title>
             <para>Each connection is represented by an instance of the
-                    <classname>guacConfigGroup</classname> object class, which is simply an extended
-                version of the standard LDAP <classname>groupOfNames</classname> which provides a
-                protocol and set of parameters. Only members of the
-                    <classname>guacConfigGroup</classname> will have access to the corresponding
-                connection.</para>
+                    <classname>guacConfigGroup</classname> object class, an extended version of the
+                standard LDAP <classname>groupOfNames</classname>, which provides a protocol and set
+                of parameters. Only members of the <classname>guacConfigGroup</classname> will have
+                access to the corresponding connection.</para>
             <para>The <classname>guacConfigGroup</classname> object class provides two new
                 attributes in addition to those provided by
                 <classname>groupOfNames</classname>:</para>
@@ -343,10 +327,10 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
                 <varlistentry>
                     <term><property>guacConfigProtocol</property></term>
                     <listitem>
-                        <para>The protocol associated with the connection, such as "vnc" or "rdp".
-                            This attribute is required for every
-                                <classname>guacConfigGroup</classname> and can be given only
-                            once.</para>
+                        <para>The protocol associated with the connection, such as
+                                "<constant>vnc</constant>" or "<constant>rdp</constant>". This
+                            attribute is required for every <classname>guacConfigGroup</classname>
+                            and can be given only once.</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>
@@ -355,7 +339,7 @@ ldap-config-base-dn:     <replaceable>ou=groups,dc=example,dc=net</replaceable><
                         <para>The name and value of a parameter for the specified protocol. This is
                             given as
                                     <code><replaceable>name</replaceable>=<replaceable>value</replaceable></code>,
-                            where "name" is the name of the parameter as defined by the
+                            where "name" is the name of the parameter, as defined by the
                             documentation for the protocol specified, and "value" is any allowed
                             value for that parameter.</para>
                         <para>This attribute can be given multiple times for the same

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -65,6 +65,9 @@
                 <para>Copy <filename>guacamole-auth-noauth-0.9.6.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </listitem>
+            <listitem>
+                <para>Configure Guacamole to use NoAuth, as described below.</para>
+            </listitem>
         </orderedlist>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -7,118 +7,150 @@
         <primary>disabling authentication</primary>
     </indexterm>
     <indexterm>
-        <primary>noauth</primary>
+        <primary>NoAuth</primary>
     </indexterm>
     <para>Guacamole normally enforces authentication, requiring all users to have a corresponding
         set of credentials. If you would rather just type in your server's URL and gain access to
-        your computer, you can do this with the "noauth" extension.</para>
-    <para>guacamole-auth-noauth removes all authentication, giving anyone that visits your server
-        access to the same set of connections dictated by an XML configuration file. It is an
-        authentication implementation in its own right, and thus doesn't truly "disable"
-        authentication per se. Instead, it grants anyone access without requiring a username or
-        password.</para>
-    <para>The security implications of this should be obvious - anyone with access to your Guacamole
-        instance will have access to your remote desktops.</para>
-    <section xml:id="installing-noauth">
-        <title>Installing the "noauth" extension</title>
-        <para>The "noauth" authentication module is not included in the main Guacamole bundle nor is
-            it enabled by default. You must use the download link provided in the downloads section
-            of the main Guacamole site.</para>
+        your computer, you can do this with the so-called "NoAuth" extension.</para>
+    <para>The NoAuth extension still performs authentication, but does not validate any credentials,
+        giving anyone that visits your server access to the same set of connections dictated by an
+        XML configuration file. It is an authentication implementation in its own right, and thus
+        doesn't truly "disable" authentication. It simply grants anyone access without requesting a
+        username or password.</para>
+    <important>
+        <para>The security implications of this should be obvious - anyone with access to your
+            Guacamole instance will have access to your remote desktops. If you wish to effectively
+            disable authentication using NoAuth, do so with caution.</para>
+    </important>
+    <section>
+        <title>Downloading the NoAuth extension</title>
+        <para>The NoAuth authentication extension is not included in the main Guacamole bundle nor
+            is it enabled by default. You must use the download link provided in the downloads
+            section of the main Guacamole site.</para>
         <para>The downloaded <filename>.tar.gz</filename> file will contain several
             directories:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>lib/</filename></term>
+                <term><filename>guacamole-auth-noauth-0.9.6.jar</filename></term>
                 <listitem>
-                    <para>Contains all <filename>.jar</filename> files required for the "noauth"
-                        authentication module to work, including the module itself.</para>
+                    <para>The NoAuth extension itself, which must be placed in
+                            <filename>GUACAMOLE_HOME/extensions</filename>.</para>
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term><filename>example/</filename></term>
+                <term><filename>doc/example/</filename></term>
                 <listitem>
                     <para>Contains an example configuration file:
                             <filename>noauth-config.xml</filename>.</para>
                 </listitem>
             </varlistentry>
         </variablelist>
-        <para>The contents of <filename>lib/</filename> must be copied into the classpath of
-            Guacamole, which is the directory specified by the <property>lib-directory</property>
-            property in <filename>guacamole.properties</filename>. If this property is not
-            specified, simply add it. On Linux servers,
-                <filename>/var/lib/guacamole/classpath</filename> is a good choice, but it can be
-            whatever you like.</para>
-        <para>The "noauth" extension is very simple and does not require any external libraries to
-            function. The contents of the <filename>lib/</filename> directory should be simply the
-            extension itself. After copying this file in place, check that the contents match the
-            listing shown here:</para>
-        <screen><prompt>$</prompt> ls <replaceable>/var/lib/guacamole/classpath</replaceable>
-<computeroutput>guacamole-auth-noauth-0.9.6.jar</computeroutput>
-<prompt>$</prompt></screen>
-        <para>If there are other <filename>.jar</filename> files present beyond the "noauth"
-            authentication module itself (<filename>guacamole-auth-noauth-0.9.6.jar</filename>), it
-            should still work. You would only have problems if two different versions of "noauth"
-            were present.</para>
-        <section>
-            <title>Configuring Guacamole</title>
-            <para>A few properties must be added to <filename>guacamole.properties</filename> such
-                that Guacamole will load the "noauth" extension and locate its configuration
-                file:</para>
-            <programlisting># Auth provider class
-auth-provider: net.sourceforge.guacamole.net.auth.noauth.NoAuthenticationProvider
-
-# NoAuth properties
-noauth-config: <replaceable>/etc/guacamole/noauth-config.xml</replaceable></programlisting>
-            <para>The <property>auth-provider</property> property above is a standard Guacamole
-                property and tells Guacamole which authentication provider to use when
-                authenticating requests.</para>
-            <para>The <property>noauth-config</property> property defines where the XML
-                configuration file (documented below) is located. This file describes the
-                connections available to any user of your Guacamole instance and can be placed
-                anywhere so long as its location is given in
-                    <filename>guacamole.properties</filename>. On Linux servers,
-                    <filename>/etc/guacamole</filename> is a good location for Guacamole
-                configuration files, including the configuration file used by "noauth".</para>
-            <para>Now just restart Tomcat (or whatever servlet container you are using) and
-                authentication will be effectively disabled.</para>
-        </section>
     </section>
-    <section xml:id="noauth-configuration">
-        <title>Adding connections</title>
-        <indexterm>
-            <primary>configuring noauth</primary>
-        </indexterm>
-        <para>Although the "noauth" extension does not check credentials, it still requires a
-            configuration file describing which connections are available and the protocols to use.
-            This configuration is an XML file, typically called
-                <filename>noauth-config.xml</filename>.</para>
-        <para>An example <filename>noauth-config.xml</filename> file is provided in the
-                <filename>example/</filename> directory of the <filename>.tar.gz</filename> file
-            downloadable from the Guacamole site. The format is fairly straightforward, and it
-            consists only of a list of connections (configurations) and parameters:</para>
-        <informalexample>
-            <programlisting>&lt;configs>
+    <section xml:id="installing-noauth">
+        <title>Installing the NoAuth extension</title>
+        <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
+            located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
+            the NoAuth authentication extension, you must:</para>
+        <orderedlist>
+            <listitem>
+                <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
+                    does not already exist.</para>
+            </listitem>
+            <listitem>
+                <para>Remove any existing authentication extensions from
+                        <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
+                    support using multiple authentication extensions at the same time.</para>
+            </listitem>
+            <listitem>
+                <para>Copy <filename>guacamole-auth-noauth-0.9.6.jar</filename> within
+                        <filename>GUACAMOLE_HOME/extensions</filename>.</para>
+            </listitem>
+        </orderedlist>
+        <important>
+            <para>You will need to restart Guacamole by restarting your servlet container in order
+                to complete the installation. Doing this will disconnect all active users, so be
+                sure that it is safe to do so prior to attempting installation. If you do not
+                configure the NoAuth extension properly, Guacamole will not start up again until the
+                configuration is fixed.</para>
+        </important>
+        <section>
+            <title>Configuring Guacamole for NoAuth</title>
+            <para>An additional property must be added to <filename>guacamole.properties</filename>
+                such that Guacamole will load the NoAuth extension and locate its configuration
+                file:</para>
+            <programlisting># NoAuth properties
+noauth-config: <replaceable>/etc/guacamole/noauth-config.xml</replaceable></programlisting>
+            <para>The <property>noauth-config</property> property defines the location of the XML
+                configuration file required by NoAuth. This file describes the connections available
+                to any user of your Guacamole instance and can be placed anywhere so long as its
+                location is given in <filename>guacamole.properties</filename>. On Linux servers,
+                    <filename>/etc/guacamole</filename> is a good location for Guacamole
+                configuration files, including the configuration file used by NoAuth.</para>
+            <section xml:id="noauth-configuration">
+                <title>The NoAuth configuration file</title>
+                <indexterm>
+                    <primary>configuring NoAuth</primary>
+                </indexterm>
+                <para>Although the NoAuth extension does not check credentials, it still requires a
+                    configuration file describing which connections are available and the protocols
+                    to use. This configuration is an XML file, typically called
+                        <filename>noauth-config.xml</filename>.</para>
+                <para>An example configuration file is provided in the
+                        <filename>doc/example/</filename> directory of the
+                        <filename>.tar.gz</filename> file downloadable from the Guacamole site. The
+                    format is fairly straightforward, and consists only of a list of connections
+                    (configurations) and parameters:</para>
+                <informalexample>
+                    <programlisting>&lt;configs>
     &lt;config name="myconfig" protocol="rdp">
         &lt;param name="hostname" value="rdp-server" />
         &lt;param name="port" value="3389" />
     &lt;/config>
 &lt;/configs></programlisting>
-            <para>The file consists of a single <code>&lt;configs></code> tag that contains any
-                number of <code>&lt;config></code> tags, each representing a distinct connection
-                available for use.</para>
-            <para>Each <code>&lt;config></code> tag has a corresponding <code>name</code> and
-                    <code>protocol</code>. The <code>name</code> attribute defines a unique
-                identifier for the connection and tells Guacamole what text should be displayed when
-                identifying the connection. The <code>protocol</code> attribute defines the standard
-                remote desktop protocol to use, such as VNC, RDP, or SSH. These protocols must be
-                specified as lowercase due to the naming convention used by the libraries providing
-                protocol support. If the wrong case is used, Guacamole will be unable to load the
-                corresponding protocol support and the connection will fail.</para>
-            <para>The &lt;param> tags are placed within &lt;config> tags, describing a parameter
-                name/value pair. The parameters available, their names, and their allowed values are
-                protocol-specific and documented in <xref linkend="configuring-guacamole"/>.</para>
-            <para>The example above creates a new connection called "myconfig" that uses RDP to
-                connect to the server at rdp-server on port 3389.</para>
-        </informalexample>
+                    <para>The file consists of a single <code>&lt;configs></code> tag that contains
+                        any number of <code>&lt;config></code> tags, each representing a distinct
+                        connection available for use.</para>
+                    <para>Each <code>&lt;config></code> tag has a corresponding <code>name</code>
+                        and <code>protocol</code>. The <code>name</code> attribute defines a unique
+                        identifier for the connection and tells Guacamole what text should be
+                        displayed when identifying the connection. The <code>protocol</code>
+                        attribute defines the standard remote desktop protocol to use, such as
+                            "<constant>vnc</constant>", "<constant>rdp</constant>", or
+                            "<constant>ssh</constant>". These protocols must be specified as
+                        lowercase due to the naming convention used by the libraries providing
+                        protocol support. If the wrong case is used, Guacamole will be unable to
+                        load the corresponding protocol support and the connection will fail.</para>
+                    <para>The <code>&lt;param></code> tags are placed within
+                            <code>&lt;config></code> tags, describing a parameter name/value pair.
+                        The parameters available, their names, and their allowed values are
+                        protocol-specific and documented in <xref linkend="configuring-guacamole"
+                        />.</para>
+                    <para>The example above creates a new connection called "myconfig" that uses RDP
+                        to connect to the server at "rdp-server" on port 3389.</para>
+                </informalexample>
+            </section>
+        </section>
+        <section>
+            <title>Completing the installation</title>
+            <para>Guacamole will only reread <filename>guacamole.properties</filename> and load
+                newly-installed extensions during startup, so your servlet container will need to be
+                restarted before the disabled authentication will take effect. Restart your servlet
+                container and check whether your changes have been successful.</para>
+            <para>
+                <important>
+                    <para>You only need to restart your servlet container. <emphasis>You do not need
+                            to restart <package>guacd</package></emphasis>.</para>
+                    <para><package>guacd</package> is completely independent of the web application
+                        and does not deal with <filename>guacamole.properties</filename> or the
+                        authentication system in any way. Since you are already restarting the
+                        servlet container, restarting <package>guacd</package> as well technically
+                        won't hurt anything, but doing so is completely pointless.</para>
+                </important>
+            </para>
+            <para>If Guacamole does not come back online after restarting your servlet container, or
+                you are prompted for a username and password, check the logs. Problems in the
+                configuration of NoAuth extension will prevent Guacamole from starting up, and any
+                such errors will be recorded in the logs of your servlet container.</para>
+        </section>
     </section>
 </chapter>

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -24,11 +24,15 @@
     </important>
     <section>
         <title>Downloading the NoAuth extension</title>
-        <para>The NoAuth authentication extension is not included in the main Guacamole bundle nor
-            is it enabled by default. You must use the download link provided in the downloads
-            section of the main Guacamole site.</para>
-        <para>The downloaded <filename>.tar.gz</filename> file will contain several
-            directories:</para>
+        <para xmlns:xlink="http://www.w3.org/1999/xlink">The NoAuth authentication extension is
+            available separately from the main <filename>guacamole.war</filename>. The link for this
+            and all other officially-supported and compatible extensions for a particular version of
+            Guacamole are provided on the release notes for that version. You can find the release
+            notes for current versions of Guacamole here: <link
+                xlink:href="http://guac-dev.org/releases/"
+            >http://guac-dev.org/releases/</link>.</para>
+        <para xmlns:xlink="http://www.w3.org/1999/xlink">The NoAuth authentication extension is
+            packaged as a <filename>.tar.gz</filename> file containing:</para>
         <variablelist>
             <varlistentry>
                 <term><filename>guacamole-auth-noauth-0.9.6.jar</filename></term>


### PR DESCRIPTION
The install procedures for extensions have changed, now that the `GUACAMOLE_HOME/extensions` and `GUACAMOLE_HOME/lib` directories exist.
