### PR TITLE
GUAC-1198: Document use of Guacamole with Docker

### DIFF
--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xml:id="guacamole-docker" xmlns="http://docbook.org/ns/docbook" version="5.0" xml:lang="en"
+    xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>Installing Guacamole with Docker</title>
+    <indexterm>
+        <primary>docker</primary>
+    </indexterm>
+    <section>
+        <title>The <package>guacd</package> Docker image</title>
+        <section>
+            <title>Running <package>guacd</package> for use by the Guacamole Docker image</title>
+            <informalexample>
+                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d glyptodon/guacd</screen>
+            </informalexample>
+            <para><package>guacd</package> will be listening on port 4822, but this port will only
+                be available to Docker containers that have been explicitly linked to
+                        <varname><replaceable>some-guacd</replaceable></varname>.</para>
+        </section>
+        <section>
+            <title>Running <package>guacd</package> for use services by outside Docker</title>
+            <informalexample>
+                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d -p 4822:4822 glyptodon/guacd</screen>
+            </informalexample>
+            <para><package>guacd</package> will be listening on port 4822, and Docker will expose
+                this port on the same server hosting Docker. Other services, such as an instance of
+                Tomcat running outside of Docker, will be able to connect to
+                    <package>guacd</package>.</para>
+            <para>Beware of the security ramifications of doing this. There is no authentication
+                within <package>guacd</package>, so allowing access from untrusted applications is
+                dangerous. If you need to expose <package>guacd</package>, ensure that you only
+                expose it as absolutely necessary, and that only specific trusted applications have
+                access. </para>
+        </section>
+        <section>
+            <title>Connecting to <package>guacd</package> from an application</title>
+            <informalexample>
+                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-app</replaceable> --link <replaceable>some-guacd</replaceable>:guacd -d <replaceable>application-that-uses-guacd</replaceable></screen>
+            </informalexample>
+        </section>
+    </section>
+    <section>
+        <title>The Guacamole Docker image</title>
+        <para>Using this image will require an existing, running Docker container with the
+                <package>guacd</package> image, and another Docker container providing either a
+            PostgreSQL or MySQL database.</para>
+        <para>The name of the database and all associated credentials are specified with environment
+            variables given when the container is created. All other configuration information is
+            generated from the Docker links.</para>
+        <para>Beware that you will need to initialize the database manually. Guacamole will not
+            automatically create its own tables, but SQL scripts are provided to do this.</para>
+        <para>Once the Guacamole image is running, Guacamole will be accessible at
+                    <uri>http://<replaceable>[address of
+                container]</replaceable>:8080/guacamole/</uri>. The instructions below use the
+                <option>-p 8080:8080</option> option to expose this port at the level of the machine
+            hosting Docker, as well.</para>
+        <section>
+            <title>Deploying Guacamole with MySQL authentication</title>
+            <informalexample>
+                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
+    --link <replaceable>some-mysql</replaceable>:mysql      \
+    -e MYSQL_DATABASE=<replaceable>guacamole_db</replaceable>  \
+    -e MYSQL_USER=<replaceable>guacamole_user</replaceable>    \
+    -e MYSQL_PASSWORD=<replaceable>some_password</replaceable> \
+    -d -p 8080:8080 glyptodon/guacamole</screen>
+            </informalexample>
+            <para>Linking Guacamole to MySQL requires three environment variables. If any of these
+                environment variables are omitted, you will receive an error message, and the image
+                will stop:</para>
+            <variablelist>
+                <varlistentry>
+                    <term><envar>MYSQL_DATABASE</envar></term>
+                    <listitem>
+                        <para>The name of the database to use for Guacamole authentication.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><envar>MYSQL_USER</envar></term>
+                    <listitem>
+                        <para>The user that Guacamole will use to connect to MySQL.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><envar>MYSQL_PASSWORD</envar></term>
+                    <listitem>
+                        <para>The password that Guacamole will provide when connecting to MySQL as
+                                <envar>MYSQL_USER</envar>.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+            <section>
+                <title>Initializing the MySQL database</title>
+                <para>If your database is not already initialized with the Guacamole schema, you
+                    will need to do so prior to using Guacamole. A convenience script for generating
+                    the necessary SQL to do this is included in the Guacamole image.</para>
+                <para>To generate a SQL script which can be used to initialize a fresh MySQL
+                    database as documented in <xref linkend="jdbc-auth"/>:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> run --rm glyptodon/guacamole /opt/guacamole/bin/initdb.sh --mysql > <replaceable>initdb.sql</replaceable></screen>
+                </informalexample>
+                <para>Alternatively, you can use the SQL scripts included with the database
+                    authentication.</para>
+                <para>Once this script is generated, you must:</para>
+                <procedure>
+                    <step>
+                        <para>Create a database for Guacamole within MySQL, such as
+                                    <database><replaceable>guacamole_db</replaceable></database>.</para>
+                    </step>
+                    <step>
+                        <para>Create a user for Guacamole within MySQL with access to this database,
+                            such as
+                                <systemitem><replaceable>guacamole_user</replaceable></systemitem>.</para>
+                    </step>
+                    <step>
+                        <para>Run the script on the newly-created database. The process for doing
+                            this via the <command>mysql</command> utility included with MySQL is
+                            documented in <xref linkend="jdbc-auth"/>.</para>
+                    </step>
+                </procedure>
+            </section>
+        </section>
+        <section>
+            <title>Deploying Guacamole with PostgreSQL authentication</title>
+            <informalexample>
+                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
+    --link <replaceable>some-postgres</replaceable>:postgres      \
+    -e POSTGRES_DATABASE=<replaceable>guacamole_db</replaceable>  \
+    -e POSTGRES_USER=<replaceable>guacamole_user</replaceable>    \
+    -e POSTGRES_PASSWORD=<replaceable>some_password</replaceable> \
+    -d -p 8080:8080 glyptodon/guacamole</screen>
+            </informalexample>
+            <para>Linking Guacamole to PostgreSQL requires three environment variables. If any of
+                these environment variables are omitted, you will receive an error message, and the
+                image will stop:</para>
+            <variablelist>
+                <varlistentry>
+                    <term><envar>POSTGRES_DATABASE</envar></term>
+                    <listitem>
+                        <para>The name of the database to use for Guacamole authentication.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><envar>POSTGRES_USER</envar></term>
+                    <listitem>
+                        <para>The user that Guacamole will use to connect to PostgreSQL.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><envar>POSTGRES_PASSWORD</envar></term>
+                    <listitem>
+                        <para>The password that Guacamole will provide when connecting to PostgreSQL
+                            as <envar>POSTGRES_USER</envar>.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+            <section>
+                <title>Initializing the PostgreSQL database</title>
+                <para>If your database is not already initialized with the Guacamole schema, you
+                    will need to do so prior to using Guacamole. A convenience script for generating
+                    the necessary SQL to do this is included in the Guacamole image.</para>
+                <para>To generate a SQL script which can be used to initialize a fresh PostgreSQL
+                    database as documented in <xref linkend="jdbc-auth"/>:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> run --rm glyptodon/guacamole /opt/guacamole/bin/initdb.sh --postgresql > <replaceable>initdb.sql</replaceable></screen>
+                </informalexample>
+                <para>Alternatively, you can use the SQL scripts included with the database
+                    authentication.</para>
+                <para>Once this script is generated, you must:</para>
+                <procedure>
+                    <step>
+                        <para>Create a database for Guacamole within PostgreSQL, such as
+                                    <database><replaceable>guacamole_db</replaceable></database>.</para>
+                    </step>
+                    <step>
+                        <para>Run the script on the newly-created database.</para>
+                    </step>
+                    <step>
+                        <para>Create a user for Guacamole within PostgreSQL with access to the
+                            tables and sequences of this database, such as
+                                    <systemitem><replaceable>guacamole_user</replaceable></systemitem>.</para>
+                    </step>
+                </procedure>
+                <para>The process for doing this via the <command>psql</command> and
+                        <command>createdb</command> utilities included with PostgreSQL is documented
+                    in <xref linkend="jdbc-auth"/>.</para>
+            </section>
+        </section>
+    </section>
+</chapter>

--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -5,9 +5,9 @@
     <indexterm>
         <primary>docker</primary>
     </indexterm>
-    <section>
+    <section xml:id="guacd-docker-image">
         <title>The <package>guacd</package> Docker image</title>
-        <section>
+        <section xml:id="guacd-docker-guacamole">
             <title>Running <package>guacd</package> for use by the Guacamole Docker image</title>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d glyptodon/guacd</screen>
@@ -16,7 +16,7 @@
                 be available to Docker containers that have been explicitly linked to
                         <varname><replaceable>some-guacd</replaceable></varname>.</para>
         </section>
-        <section>
+        <section xml:id="guacd-docker-external">
             <title>Running <package>guacd</package> for use services by outside Docker</title>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d -p 4822:4822 glyptodon/guacd</screen>
@@ -31,14 +31,14 @@
                 expose it as absolutely necessary, and that only specific trusted applications have
                 access. </para>
         </section>
-        <section>
+        <section xml:id="guacd-docker-app">
             <title>Connecting to <package>guacd</package> from an application</title>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-app</replaceable> --link <replaceable>some-guacd</replaceable>:guacd -d <replaceable>application-that-uses-guacd</replaceable></screen>
             </informalexample>
         </section>
     </section>
-    <section>
+    <section xml:id="guacamole-docker-image">
         <title>The Guacamole Docker image</title>
         <para>Using this image will require an existing, running Docker container with the
                 <package>guacd</package> image, and another Docker container providing either a
@@ -53,7 +53,7 @@
                 container]</replaceable>:8080/guacamole/</uri>. The instructions below use the
                 <option>-p 8080:8080</option> option to expose this port at the level of the machine
             hosting Docker, as well.</para>
-        <section>
+        <section xml:id="guacamole-docker-mysql">
             <title>Deploying Guacamole with MySQL authentication</title>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
@@ -87,7 +87,7 @@
                     </listitem>
                 </varlistentry>
             </variablelist>
-            <section>
+            <section xml:id="guacamole-docker-mysql-init">
                 <title>Initializing the MySQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
                     will need to do so prior to using Guacamole. A convenience script for generating
@@ -118,7 +118,7 @@
                 </procedure>
             </section>
         </section>
-        <section>
+        <section xml:id="guacamole-docker-postgresql">
             <title>Deploying Guacamole with PostgreSQL authentication</title>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
@@ -152,7 +152,7 @@
                     </listitem>
                 </varlistentry>
             </variablelist>
-            <section>
+            <section xml:id="guacamole-docker-postgresql-init">
                 <title>Initializing the PostgreSQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
                     will need to do so prior to using Guacamole. A convenience script for generating

--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -5,88 +5,122 @@
     <indexterm>
         <primary>docker</primary>
     </indexterm>
+    <para>Guacamole can be deployed using Docker, removing the need to build
+            <package>guacamole-server</package> from source. The Guacamole project provides
+        officially-supported Docker images for both Guacamole and <package>guacd</package> which are
+        kept up-to-date with each release.</para>
+    <para>A typical Docker deployment of Guacamole will involve three separate containers, linked
+        together at creation time:</para>
+    <variablelist>
+        <varlistentry>
+            <term><systemitem>glyptodon/guacd</systemitem></term>
+            <listitem>
+                <para>Provides the <package>guacd</package> daemon, built from the released
+                        <package>guacamole-server</package> source with support for VNC, RDP, SSH,
+                    and telnet.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><systemitem>glyptodon/guacamole</systemitem></term>
+            <listitem>
+                <para>Provides the Guacamole web application running within Tomcat 8 with support
+                    for WebSocket. The configuration necessary to connect to the linked
+                        <package>guacd</package> container and MySQL or PostgreSQL database will be
+                    generated automatically when the image starts.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+    <variablelist>
+        <varlistentry>
+            <term><systemitem>mysql</systemitem> or <systemitem>postgresql</systemitem></term>
+            <listitem>
+                <para>Provides the database that Guacamole will use for authentication and storage
+                    of connection configuration data.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+    <para>This separation is important, as it facilitates upgrades and maintains proper separation
+        of concerns. With the database separate from Guacamole and <package>guacd</package>, those
+        containers can be freely destroyed and recreated at will. The only container which must
+        persist data through upgrades is the database.</para>
     <section xml:id="guacd-docker-image">
-        <title>The <package>guacd</package> Docker image</title>
+        <title>Running the <package>guacd</package> Docker image</title>
+        <para>The <package>guacd</package> Docker image is built from the released
+                <package>guacamole-server</package> source with support for VNC, RDP, SSH, and
+            telnet. Common pitfalls like installing the required dependencies, installing fonts for
+            SSH or telnet, and ensuring the FreeRDP plugins are installed to the correct location
+            are all taken care of. It will simply just work.</para>
         <section xml:id="guacd-docker-guacamole">
             <title>Running <package>guacd</package> for use by the Guacamole Docker image</title>
+            <para>When running the <package>guacd</package> image with the intent of linking to a
+                Guacamole container, no ports need be exposed on the network. Access to these ports
+                will be handled automatically by Docker during linking, and the Guacamole image will
+                properly detect and configure the connection to <package>guacd</package>.</para>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d glyptodon/guacd</screen>
             </informalexample>
-            <para><package>guacd</package> will be listening on port 4822, but this port will only
-                be available to Docker containers that have been explicitly linked to
-                        <varname><replaceable>some-guacd</replaceable></varname>.</para>
+            <para>When run in this manner, <package>guacd</package> will be listening on its default
+                port 4822, but this port will only be available to Docker containers that have been
+                explicitly linked to
+                <varname><replaceable>some-guacd</replaceable></varname>.</para>
         </section>
         <section xml:id="guacd-docker-external">
-            <title>Running <package>guacd</package> for use services by outside Docker</title>
+            <title>Running <package>guacd</package> for use by services outside Docker</title>
+            <para>If you are not going to use the Guacamole image, you can still leverage the
+                    <package>guacd</package> image for ease of installation and maintenance. By
+                exposing the <package>guacd</package> port, 4822, services external to Docker will
+                be able to access <package>guacd</package>.</para>
+            <important>
+                <para><emphasis>Take great care when doing this</emphasis> -
+                        <package>guacd</package> is a passive proxy and does not perform any kind of
+                    authentication.</para>
+                <para>If you do not properly isolate <package>guacd</package> from untrusted parts
+                    of your network, malicious users may be able to use <package>guacd</package> as
+                    a jumping point to other systems.</para>
+            </important>
             <informalexample>
                 <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacd</replaceable> -d -p 4822:4822 glyptodon/guacd</screen>
             </informalexample>
-            <para><package>guacd</package> will be listening on port 4822, and Docker will expose
-                this port on the same server hosting Docker. Other services, such as an instance of
-                Tomcat running outside of Docker, will be able to connect to
-                    <package>guacd</package>.</para>
-            <para>Beware of the security ramifications of doing this. There is no authentication
-                within <package>guacd</package>, so allowing access from untrusted applications is
-                dangerous. If you need to expose <package>guacd</package>, ensure that you only
-                expose it as absolutely necessary, and that only specific trusted applications have
-                access. </para>
-        </section>
-        <section xml:id="guacd-docker-app">
-            <title>Connecting to <package>guacd</package> from an application</title>
-            <informalexample>
-                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-app</replaceable> --link <replaceable>some-guacd</replaceable>:guacd -d <replaceable>application-that-uses-guacd</replaceable></screen>
-            </informalexample>
+            <para><package>guacd</package> will now be listening on port 4822, and Docker will
+                expose this port on the same server hosting Docker. Other services, such as an
+                instance of Tomcat running outside of Docker, will be able to connect to
+                    <package>guacd</package> directly.</para>
         </section>
     </section>
     <section xml:id="guacamole-docker-image">
         <title>The Guacamole Docker image</title>
-        <para>Using this image will require an existing, running Docker container with the
-                <package>guacd</package> image, and another Docker container providing either a
-            PostgreSQL or MySQL database.</para>
+        <para>The Guacamole Docker image is built on top of a standard Tomcat 8 image and takes care
+            of all configuration automatically. When properly linked to a <package>guacd</package>
+            container and either a PostgreSQL or MySQL database, the necessary Guacamole
+            configuration will be automatically generated at startup.</para>
         <para>The name of the database and all associated credentials are specified with environment
             variables given when the container is created. All other configuration information is
             generated from the Docker links.</para>
-        <para>Beware that you will need to initialize the database manually. Guacamole will not
-            automatically create its own tables, but SQL scripts are provided to do this.</para>
+        <important>
+            <para><emphasis>You will need to initialize the database manually</emphasis>. Guacamole
+                will not automatically create its own tables, but SQL scripts are provided to do
+                this.</para>
+        </important>
         <para>Once the Guacamole image is running, Guacamole will be accessible at
-                    <uri>http://<replaceable>[address of
-                container]</replaceable>:8080/guacamole/</uri>. The instructions below use the
-                <option>-p 8080:8080</option> option to expose this port at the level of the machine
-            hosting Docker, as well.</para>
+                    <uri>http://<replaceable>HOSTNAME</replaceable>:8080/guacamole/</uri>, where
+                <replaceable>HOSTNAME</replaceable> is the hostname or address of the machine
+            hosting Docker.</para>
         <section xml:id="guacamole-docker-mysql">
             <title>Deploying Guacamole with MySQL authentication</title>
-            <informalexample>
-                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
-    --link <replaceable>some-mysql</replaceable>:mysql      \
-    -e MYSQL_DATABASE=<replaceable>guacamole_db</replaceable>  \
-    -e MYSQL_USER=<replaceable>guacamole_user</replaceable>    \
-    -e MYSQL_PASSWORD=<replaceable>some_password</replaceable> \
-    -d -p 8080:8080 glyptodon/guacamole</screen>
-            </informalexample>
-            <para>Linking Guacamole to MySQL requires three environment variables. If any of these
-                environment variables are omitted, you will receive an error message, and the image
-                will stop:</para>
-            <variablelist>
-                <varlistentry>
-                    <term><envar>MYSQL_DATABASE</envar></term>
-                    <listitem>
-                        <para>The name of the database to use for Guacamole authentication.</para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term><envar>MYSQL_USER</envar></term>
-                    <listitem>
-                        <para>The user that Guacamole will use to connect to MySQL.</para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term><envar>MYSQL_PASSWORD</envar></term>
-                    <listitem>
-                        <para>The password that Guacamole will provide when connecting to MySQL as
-                                <envar>MYSQL_USER</envar>.</para>
-                    </listitem>
-                </varlistentry>
-            </variablelist>
+            <para>Before deploying Guacamole with the intent of using MySQL for authentication,
+                please ensure that you have each of the following already prepared:</para>
+            <orderedlist>
+                <listitem>
+                    <para>A Docker container running the <systemitem>glyptodon/guacd</systemitem>
+                        image. Guacamole needs <package>guacd</package> in order to function, and
+                        the Guacamole Docker image depends on a linked Docker container running
+                            <package>guacd</package>.</para>
+                </listitem>
+                <listitem>
+                    <para>A Docker container running the <systemitem>mysql</systemitem>
+                        image.</para>
+                </listitem>
+            </orderedlist>
             <section xml:id="guacamole-docker-mysql-init">
                 <title>Initializing the MySQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
@@ -117,41 +151,98 @@
                     </step>
                 </procedure>
             </section>
+            <section>
+                <title>Deploying Guacamole</title>
+                <para>Linking Guacamole to MySQL will require three environment variables. These
+                    variables collectively describe how Guacamole will connect to MySQL:</para>
+                <informaltable frame="all">
+                    <tgroup cols="2">
+                        <colspec colname="c1" colnum="1" colwidth="1*"/>
+                        <colspec colname="c2" colnum="2" colwidth="4*"/>
+                        <thead>
+                            <row>
+                                <entry>Variable</entry>
+                                <entry>Description</entry>
+                            </row>
+                        </thead>
+                        <tbody>
+                            <row>
+                                <entry><envar>MYSQL_DATABASE</envar></entry>
+                                <entry>
+                                    <para>The name of the database to use for Guacamole
+                                        authentication.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><envar>MYSQL_USER</envar></entry>
+                                <entry>
+                                    <para>The user that Guacamole will use to connect to
+                                        MySQL.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><envar>MYSQL_PASSWORD</envar></entry>
+                                <entry>
+                                    <para>The password that Guacamole will provide when connecting
+                                        to MySQL as <envar>MYSQL_USER</envar>.</para>
+                                </entry>
+                            </row>
+                        </tbody>
+                    </tgroup>
+                </informaltable>
+                <para>Once your <package>guacd</package> container is ready, and the values of the
+                    above variables are known, Guacamole can be deployed through Docker:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
+    --link <replaceable>some-mysql</replaceable>:mysql      \
+    -e MYSQL_DATABASE=<replaceable>guacamole_db</replaceable>  \
+    -e MYSQL_USER=<replaceable>guacamole_user</replaceable>    \
+    -e MYSQL_PASSWORD=<replaceable>some_password</replaceable> \
+    -d -p 8080:8080 glyptodon/guacamole</screen>
+                </informalexample>
+                <para>If any of the configuration environment variables are omitted, you will
+                    receive an error message, and the image will stop. You will then need to
+                    recreate the container with the proper variables specified.</para>
+            </section>
+            <section>
+                <title>Verifying the Guacamole install</title>
+                <para>Now that the Guacamole image is running, Guacamole should be accessible at
+                            <uri>http://<replaceable>HOSTNAME</replaceable>:8080/guacamole/</uri>,
+                    where <replaceable>HOSTNAME</replaceable> is the hostname or address of the
+                    machine hosting Docker.</para>
+                <para>If you cannot access Guacamole, check the logs using Docker to determine if
+                    something is wrong. Configuration parameters may have been given incorrectly, or
+                    the database may be improperly initialized:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> logs <replaceable>some-guacamole</replaceable></screen>
+                </informalexample>
+                <para>If Guacamole has been successfully installed, you will see the Guacamole login
+                    screen. The database initialization scripts will create the default
+                    administrative user as "<systemitem>guacadmin</systemitem>" with the password
+                        "<systemitem>guacadmin</systemitem>". You should change your password
+                    immediately after verifying that your login works.</para>
+                <para>Once you have verified Guacamole has been deployed successfully, you can
+                    configure Guacamole through the web interface as described in <xref
+                        xmlns:xlink="http://www.w3.org/1999/xlink" linkend="administration"
+                    />.</para>
+            </section>
         </section>
         <section xml:id="guacamole-docker-postgresql">
             <title>Deploying Guacamole with PostgreSQL authentication</title>
-            <informalexample>
-                <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
-    --link <replaceable>some-postgres</replaceable>:postgres      \
-    -e POSTGRES_DATABASE=<replaceable>guacamole_db</replaceable>  \
-    -e POSTGRES_USER=<replaceable>guacamole_user</replaceable>    \
-    -e POSTGRES_PASSWORD=<replaceable>some_password</replaceable> \
-    -d -p 8080:8080 glyptodon/guacamole</screen>
-            </informalexample>
-            <para>Linking Guacamole to PostgreSQL requires three environment variables. If any of
-                these environment variables are omitted, you will receive an error message, and the
-                image will stop:</para>
-            <variablelist>
-                <varlistentry>
-                    <term><envar>POSTGRES_DATABASE</envar></term>
-                    <listitem>
-                        <para>The name of the database to use for Guacamole authentication.</para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term><envar>POSTGRES_USER</envar></term>
-                    <listitem>
-                        <para>The user that Guacamole will use to connect to PostgreSQL.</para>
-                    </listitem>
-                </varlistentry>
-                <varlistentry>
-                    <term><envar>POSTGRES_PASSWORD</envar></term>
-                    <listitem>
-                        <para>The password that Guacamole will provide when connecting to PostgreSQL
-                            as <envar>POSTGRES_USER</envar>.</para>
-                    </listitem>
-                </varlistentry>
-            </variablelist>
+            <para>Before deploying Guacamole with the intent of using PostgreSQL for authentication,
+                please ensure that you have each of the following already prepared:</para>
+            <orderedlist>
+                <listitem>
+                    <para>A Docker container running the <systemitem>glyptodon/guacd</systemitem>
+                        image. Guacamole needs <package>guacd</package> in order to function, and
+                        the Guacamole Docker image depends on a linked Docker container running
+                            <package>guacd</package>.</para>
+                </listitem>
+                <listitem>
+                    <para>A Docker container running the <systemitem>postgresql</systemitem>
+                        image.</para>
+                </listitem>
+            </orderedlist>
             <section xml:id="guacamole-docker-postgresql-init">
                 <title>Initializing the PostgreSQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
@@ -182,6 +273,82 @@
                 <para>The process for doing this via the <command>psql</command> and
                         <command>createdb</command> utilities included with PostgreSQL is documented
                     in <xref linkend="jdbc-auth"/>.</para>
+            </section>
+            <section>
+                <title>Deploying Guacamole</title>
+                <para>Linking Guacamole to your PostgreSQL database will require three environment
+                    variables. These variables collectively describe how Guacamole will connect to
+                    PostgreSQL:</para>
+                <informaltable frame="all">
+                    <tgroup cols="2">
+                        <colspec colname="c1" colnum="1" colwidth="1*"/>
+                        <colspec colname="c2" colnum="2" colwidth="4*"/>
+                        <thead>
+                            <row>
+                                <entry>Variable</entry>
+                                <entry>Description</entry>
+                            </row>
+                        </thead>
+                        <tbody>
+                            <row>
+                                <entry><envar>POSTGRES_DATABASE</envar></entry>
+                                <entry>
+                                    <para>The name of the database to use for Guacamole
+                                        authentication.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><envar>POSTGRES_USER</envar></entry>
+                                <entry>
+                                    <para>The user that Guacamole will use to connect to
+                                        PostgreSQL.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><envar>POSTGRES_PASSWORD</envar></entry>
+                                <entry>
+                                    <para>The password that Guacamole will provide when connecting
+                                        to PostgreSQL as <envar>POSTGRES_USER</envar>.</para>
+                                </entry>
+                            </row>
+                        </tbody>
+                    </tgroup>
+                </informaltable>
+                <para>Once your <package>guacd</package> container is ready, and the values of the
+                    above variables are known, Guacamole can be deployed through Docker:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> run --name <replaceable>some-guacamole</replaceable> --link <replaceable>some-guacd</replaceable>:guacd \
+    --link <replaceable>some-postgres</replaceable>:postgres      \
+    -e POSTGRES_DATABASE=<replaceable>guacamole_db</replaceable>  \
+    -e POSTGRES_USER=<replaceable>guacamole_user</replaceable>    \
+    -e POSTGRES_PASSWORD=<replaceable>some_password</replaceable> \
+    -d -p 8080:8080 glyptodon/guacamole</screen>
+                </informalexample>
+                <para>If any of the configuration environment variables are omitted, you will
+                    receive an error message, and the image will stop. You will then need to
+                    recreate the container with the proper variables specified.</para>
+            </section>
+            <section>
+                <title>Verifying the Guacamole install</title>
+                <para>Now that the Guacamole image is running, Guacamole should be accessible at
+                            <uri>http://<replaceable>HOSTNAME</replaceable>:8080/guacamole/</uri>,
+                    where <replaceable>HOSTNAME</replaceable> is the hostname or address of the
+                    machine hosting Docker.</para>
+                <para>If you cannot access Guacamole, check the logs using Docker to determine if
+                    something is wrong. Configuration parameters may have been given incorrectly, or
+                    the database may be improperly initialized:</para>
+                <informalexample>
+                    <screen><prompt>$</prompt> <command>docker</command> logs <replaceable>some-guacamole</replaceable></screen>
+                </informalexample>
+                <para>If Guacamole has been successfully installed, you will see the Guacamole login
+                    screen. The database initialization scripts will create the default
+                    administrative user as "<systemitem>guacadmin</systemitem>" with the password
+                        "<systemitem>guacadmin</systemitem>". You should change your password
+                    immediately after verifying that your login works.</para>
+                <para>Once you have verified Guacamole has been deployed successfully, you can
+                    configure Guacamole through the web interface as described in <xref
+                        xmlns:xlink="http://www.w3.org/1999/xlink" linkend="administration"
+                    />.</para>
             </section>
         </section>
     </section>

--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -6,9 +6,9 @@
         <primary>docker</primary>
     </indexterm>
     <para>Guacamole can be deployed using Docker, removing the need to build
-            <package>guacamole-server</package> from source. The Guacamole project provides
-        officially-supported Docker images for both Guacamole and <package>guacd</package> which are
-        kept up-to-date with each release.</para>
+            <package>guacamole-server</package> from source or configure the web application
+        manually. The Guacamole project provides officially-supported Docker images for both
+        Guacamole and <package>guacd</package> which are kept up-to-date with each release.</para>
     <para>A typical Docker deployment of Guacamole will involve three separate containers, linked
         together at creation time:</para>
     <variablelist>
@@ -145,11 +145,11 @@
                                 <systemitem><replaceable>guacamole_user</replaceable></systemitem>.</para>
                     </step>
                     <step>
-                        <para>Run the script on the newly-created database. The process for doing
-                            this via the <command>mysql</command> utility included with MySQL is
-                            documented in <xref linkend="jdbc-auth"/>.</para>
+                        <para>Run the script on the newly-created database.</para>
                     </step>
                 </procedure>
+                <para>The process for doing this via the <command>mysql</command> utility included
+                    with MySQL is documented in <xref linkend="jdbc-auth"/>.</para>
             </section>
             <section>
                 <title xml:id="deploying-guacamole-docker-mysql">Deploying Guacamole</title>
@@ -219,10 +219,11 @@
                 <para>If Guacamole has been successfully installed, you will see the Guacamole login
                     screen. The database initialization scripts will create the default
                     administrative user as "<systemitem>guacadmin</systemitem>" with the password
-                        "<systemitem>guacadmin</systemitem>". You should change your password
-                    immediately after verifying that your login works.</para>
+                        "<systemitem>guacadmin</systemitem>". <emphasis>You should change your
+                        password immediately after verifying that your login
+                    works</emphasis>.</para>
                 <para>Once you have verified Guacamole has been deployed successfully, you can
-                    configure Guacamole through the web interface as described in <xref
+                    create connections and add users through the web interface as described in <xref
                         xmlns:xlink="http://www.w3.org/1999/xlink" linkend="administration"
                     />.</para>
             </section>
@@ -343,10 +344,11 @@
                 <para>If Guacamole has been successfully installed, you will see the Guacamole login
                     screen. The database initialization scripts will create the default
                     administrative user as "<systemitem>guacadmin</systemitem>" with the password
-                        "<systemitem>guacadmin</systemitem>". You should change your password
-                    immediately after verifying that your login works.</para>
+                        "<systemitem>guacadmin</systemitem>". <emphasis>You should change your
+                        password immediately after verifying that your login
+                    works</emphasis>.</para>
                 <para>Once you have verified Guacamole has been deployed successfully, you can
-                    configure Guacamole through the web interface as described in <xref
+                    create connections and add users through the web interface as described in <xref
                         xmlns:xlink="http://www.w3.org/1999/xlink" linkend="administration"
                     />.</para>
             </section>

--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -121,7 +121,7 @@
                         image.</para>
                 </listitem>
             </orderedlist>
-            <section xml:id="guacamole-docker-mysql-init">
+            <section xml:id="initializing-guacamole-docker-mysql">
                 <title>Initializing the MySQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
                     will need to do so prior to using Guacamole. A convenience script for generating
@@ -152,7 +152,7 @@
                 </procedure>
             </section>
             <section>
-                <title>Deploying Guacamole</title>
+                <title xml:id="deploying-guacamole-docker-mysql">Deploying Guacamole</title>
                 <para>Linking Guacamole to MySQL will require three environment variables. These
                     variables collectively describe how Guacamole will connect to MySQL:</para>
                 <informaltable frame="all">
@@ -204,7 +204,7 @@
                     receive an error message, and the image will stop. You will then need to
                     recreate the container with the proper variables specified.</para>
             </section>
-            <section>
+            <section xml:id="verifying-guacamole-docker-mysql">
                 <title>Verifying the Guacamole install</title>
                 <para>Now that the Guacamole image is running, Guacamole should be accessible at
                             <uri>http://<replaceable>HOSTNAME</replaceable>:8080/guacamole/</uri>,
@@ -243,7 +243,7 @@
                         image.</para>
                 </listitem>
             </orderedlist>
-            <section xml:id="guacamole-docker-postgresql-init">
+            <section xml:id="initializing-guacamole-docker-postgresql">
                 <title>Initializing the PostgreSQL database</title>
                 <para>If your database is not already initialized with the Guacamole schema, you
                     will need to do so prior to using Guacamole. A convenience script for generating
@@ -274,7 +274,7 @@
                         <command>createdb</command> utilities included with PostgreSQL is documented
                     in <xref linkend="jdbc-auth"/>.</para>
             </section>
-            <section>
+            <section xml:id="deploying-guacamole-docker-postgresql">
                 <title>Deploying Guacamole</title>
                 <para>Linking Guacamole to your PostgreSQL database will require three environment
                     variables. These variables collectively describe how Guacamole will connect to
@@ -328,7 +328,7 @@
                     receive an error message, and the image will stop. You will then need to
                     recreate the container with the proper variables specified.</para>
             </section>
-            <section>
+            <section xml:id="verifying-guacamole-docker-postgresql">
                 <title>Verifying the Guacamole install</title>
                 <para>Now that the Guacamole image is running, Guacamole should be accessible at
                             <uri>http://<replaceable>HOSTNAME</replaceable>:8080/guacamole/</uri>,

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter xml:id="installing-guacamole" xmlns="http://docbook.org/ns/docbook" version="5.0"
     xml:lang="en" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <title>Installing Guacamole</title>
+    <title>Installing Guacamole natively</title>
     <indexterm>
         <primary>installing</primary>
     </indexterm>
@@ -806,128 +806,6 @@ guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.6 started</comput
             <para>WebSocket is supported in Guacamole for Tomcat 7.0.37 or higher, Jetty 8 or
                 higher, and any servlet container supporting JSR 356, the standardized Java API for
                 WebSocket.</para>
-        </section>
-    </section>
-    <section xml:id="mod-proxy">
-        <title>Using Apache as a frontend (<package>mod_proxy</package>)</title>
-        <para>Many users end up serving Guacamole through Apache using <package>mod_proxy</package>,
-            a module which allows Apache to be used as a reverse proxy for other servers, such as a
-            servlet container like Tomcat. The need to do this can range from simply wanting to use
-            port 80, to sharing an SSL certificate with your web server, to security and load
-            balancing.</para>
-        <para>By default, servlet containers like Tomcat listen on port 8080, which is not the
-            standard HTTP port (port 80). If you are using Linux (or another UNIX system), only the
-            root user can run programs which listen on ports less than 1024, including port 80, and
-            reducing the number of programs that run with root privileges is always a good
-            idea.</para>
-        <para>If you have an SSL certificate, it may make sense to use Apache for SSL processing and
-            save Tomcat from having to do this itself, which may not be as efficient. Again, this
-            also makes sense from the perspective of security, as it reduces the number of users
-            that require read access to identifying certificates.</para>
-        <para>While load balancing won't be covered here, if you are expecting large numbers of
-            users, balancing the load on Tomcat across multiple Tomcat instances is a common
-            solution.</para>
-        <important>
-            <para>Beware that, like the rest of this manual, we assume here that you are using
-                Tomcat. If you are using a different servlet container, the same principles apply,
-                and the Apache configuration examples will still be valid.</para>
-        </important>
-        <section>
-            <title>Configuring Tomcat for HTTP</title>
-            <para>Tomcat is most likely already configured to listen for HTTP connections on port
-                8080 as this is the default. In the case that the default HTTP connector has been
-                disabled or removed, you need to add a connector entry to
-                    <filename>conf/server.xml</filename>:</para>
-            <informalexample>
-                <programlisting>&lt;Connector port="8080" protocol="HTTP/1.1" 
-           connectionTimeout="20000"
-           URIEncoding="UTF-8"
-           redirectPort="8443" /></programlisting>
-            </informalexample>
-            <important>
-                <para>If you want to edit or add this connector just to change the port used by
-                    Tomcat to port 80, you should consider simply proxying the original port through
-                    Apache instead. On Linux and UNIX systems, a process must be running with root
-                    privileges to listen on any port under 1024, including port 80. Proxying Tomcat
-                    through Apache means Tomcat can run as a reduced-privilege user, while Apache
-                    can bear the burden of root privileges. Further, as Apache is a native
-                    application, it can make system calls to safely drop root privileges once the
-                    port is open; a Java application like Tomcat cannot do this.</para>
-            </important>
-            <para>Be sure to specify the <code>URIEncoding="UTF-8"</code> attribute as above to
-                ensure that connection names, user names, etc. are properly received. If you will be
-                creating connections that have Cyrillic, Chinese, Japanese, etc. characters in the
-                names or parameter values, this attribute is required.</para>
-        </section>
-        <section>
-            <title>Configuring Apache and <package>mod_proxy</package></title>
-            <para>Configuring Apache to proxy HTTP requests requires using the
-                    <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
-                directives, which are provided by the <package>mod_proxy</package> module. These
-                directives describe how HTTP traffic should be routed to the web server behind the
-                proxy (Tomcat, in our case):</para>
-            <informalexample>
-                <programlisting>&lt;Location /guacamole/>
-    Order allow,deny
-    Allow from all
-    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
-    ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
-&lt;/Location></programlisting>
-            </informalexample>
-            <para>The most important thing in this entire section is the option
-                    <option>flushpackets=on</option>. Most proxies, including
-                    <package>mod_proxy</package>, will buffer all data sent over the connection,
-                waiting until the connection is closed before sending that data to the client. As
-                Guacamole's tunnel will stream data to the client over an open connection, buffering
-                this stream breaks Guacamole's communication.</para>
-            <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
-                    Guacamole will not work</emphasis>.</para>
-        </section>
-        <section xml:id="disable-tunnel-logging">
-            <title>Disable logging of tunnel requests</title>
-            <para>The Guacamole HTTP tunnel works by transferring a continuous stream of data over
-                multiple short-lived streams, each associated with a separate HTTP request. Each
-                HTTP request will be logged by Apache if you do not explicitly disable logging of
-                those requests.</para>
-            <para>Apache provides a means of matching URL patterns and setting environment variables
-                based on whether the URL matches. Logging can then be restricted to requests which
-                lack this environment variable:</para>
-            <informalexample>
-                <programlisting>SetEnvIf Request_URI "^<replaceable>/guacamole</replaceable>/tunnel" dontlog
-CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dontlog</programlisting>
-            </informalexample>
-            <para>There is little value in a log file filled with identical tunnel requests.</para>
-            <para>Note that if you are serving Guacamole under a path different from
-                    <uri>/guacamole/</uri>, you will need to change the value of
-                    <parameter>Request_URI</parameter> above accordingly.</para>
-        </section>
-        <section xml:id="change-web-app-path">
-            <title>Proxying under a different path</title>
-            <para>If you wish to serve Guacamole through Apache under a different path than it is
-                served under Tomcat, the configuration required for Apache will be slightly
-                different than the examples above due to cookies.</para>
-            <para>When a user logs in to Guacamole, a new session is created, and that session is
-                associated with a cookie sent to the user after they successfully log in. This
-                cookie is specific to the absolute path of the web application
-                    (<uri>/guacamole</uri>). If the path being used for Guacamole under Apache
-                differs from that used by Tomcat, the path in the cookie needs to be modified.
-                Thankfully, <package>mod_proxy</package> has a directive for this:
-                    <parameter>ProxyPassReverseCookiePath</parameter>.</para>
-            <informalexample>
-                <programlisting>&lt;Location /<replaceable>new-path/</replaceable>>
-    Order allow,deny
-    Allow from all
-    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
-    ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
-    ProxyPassReverseCookiePath /guacamole/ <replaceable>/new-path/</replaceable>
-&lt;/Location></programlisting>
-            </informalexample>
-            <para>The configuration shown above is similar to the configuration shown for generic
-                HTTP proxying, except that the additional
-                    <parameter>ProxyPassReverseCookiePath</parameter> directive is given,
-                instructing <package>mod_proxy</package> to update the cookie path, changing
-                    <uri>/guacamole/</uri> to <uri>/new-path/</uri>, the same path specified when
-                the location was declared.</para>
         </section>
     </section>
 </chapter>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -227,32 +227,32 @@ Type "help" for help.
         <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
             located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
             the database authentication extension, you must:</para>
-        <orderedlist>
-            <listitem>
+        <procedure>
+            <step>
                 <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
                     does not already exist.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Remove any existing authentication extensions from
                         <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
                     support using multiple authentication extensions at the same time.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.6.jar</filename>
                     <emphasis>or</emphasis>
                     <filename>guacamole-auth-jdbc-postgresql-0.9.6.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
                     using MySQL/MariaDB or PostgreSQL.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Copy the JDBC driver for your database to
                         <filename>GUACAMOLE_HOME/lib</filename>. Without a JDBC driver for your
                     database, Guacamole will not be able to connect and authenticate users.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Configure Guacamole to use database authentication, as described below.</para>
-            </listitem>
-        </orderedlist>
+            </step>
+        </procedure>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order
                 to complete the installation. Doing this will disconnect all active users, so be

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -172,24 +172,24 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
         <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
             located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
             the LDAP authentication extension, you must:</para>
-        <orderedlist>
-            <listitem>
+        <procedure>
+            <step>
                 <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
                     does not already exist.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Remove any existing authentication extensions from
                         <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
                     support using multiple authentication extensions at the same time.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Copy <filename>guacamole-auth-ldap-0.9.6.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Configure Guacamole to use LDAP authentication, as described below.</para>
-            </listitem>
-        </orderedlist>
+            </step>
+        </procedure>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order
                 to complete the installation. Doing this will disconnect all active users, so be

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -55,24 +55,24 @@
         <para>Guacamole extensions are self-contained <filename>.jar</filename> files which are
             located within the <filename>GUACAMOLE_HOME/extensions</filename> directory. To install
             the NoAuth authentication extension, you must:</para>
-        <orderedlist>
-            <listitem>
+        <procedure>
+            <step>
                 <para>Create the <filename>GUACAMOLE_HOME/extensions</filename> directory, if it
                     does not already exist.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Remove any existing authentication extensions from
                         <filename>GUACAMOLE_HOME/extensions</filename>. Guacamole does not currently
                     support using multiple authentication extensions at the same time.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Copy <filename>guacamole-auth-noauth-0.9.6.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
-            </listitem>
-            <listitem>
+            </step>
+            <step>
                 <para>Configure Guacamole to use NoAuth, as described below.</para>
-            </listitem>
-        </orderedlist>
+            </step>
+        </procedure>
         <important>
             <para>You will need to restart Guacamole by restarting your servlet container in order
                 to complete the installation. Doing this will disconnect all active users, so be

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xml:id="proxying-guacamole" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>Proxying Guacamole</title>
+    <section>
+        <title>Nginx</title>
+        <informalexample>
+            <programlisting>map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+
+    listen 443;
+
+    location / {
+        proxy_pass http://localhost:8080/guacamole/;
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_cookie_path /guacamole/ /;
+        access_log off;
+    }
+
+    ssl on;
+    ssl_certificate     /path/to/certificate.crt;
+    ssl_certificate_key /path/to/private_key.key;
+
+}</programlisting>
+        </informalexample>
+    </section>
+    <section xml:id="mod-proxy">
+        <title>Apache and <package>mod_proxy</package></title>
+        <para>Many users end up serving Guacamole through Apache using <package>mod_proxy</package>,
+            a module which allows Apache to be used as a reverse proxy for other servers, such as a
+            servlet container like Tomcat. The need to do this can range from simply wanting to use
+            port 80, to sharing an SSL certificate with your web server, to security and load
+            balancing.</para>
+        <para>By default, servlet containers like Tomcat listen on port 8080, which is not the
+            standard HTTP port (port 80). If you are using Linux (or another UNIX system), only the
+            root user can run programs which listen on ports less than 1024, including port 80, and
+            reducing the number of programs that run with root privileges is always a good
+            idea.</para>
+        <para>If you have an SSL certificate, it may make sense to use Apache for SSL processing and
+            save Tomcat from having to do this itself, which may not be as efficient. Again, this
+            also makes sense from the perspective of security, as it reduces the number of users
+            that require read access to identifying certificates.</para>
+        <para>While load balancing won't be covered here, if you are expecting large numbers of
+            users, balancing the load on Tomcat across multiple Tomcat instances is a common
+            solution.</para>
+        <important>
+            <para>Beware that, like the rest of this manual, we assume here that you are using
+                Tomcat. If you are using a different servlet container, the same principles apply,
+                and the Apache configuration examples will still be valid.</para>
+        </important>
+        <section>
+            <title>Configuring Tomcat for HTTP</title>
+            <para>Tomcat is most likely already configured to listen for HTTP connections on port
+                8080 as this is the default. In the case that the default HTTP connector has been
+                disabled or removed, you need to add a connector entry to
+                    <filename>conf/server.xml</filename>:</para>
+            <informalexample>
+                <programlisting>&lt;Connector port="8080" protocol="HTTP/1.1" 
+           connectionTimeout="20000"
+           URIEncoding="UTF-8"
+           redirectPort="8443" /></programlisting>
+            </informalexample>
+            <important>
+                <para>If you want to edit or add this connector just to change the port used by
+                    Tomcat to port 80, you should consider simply proxying the original port through
+                    Apache instead. On Linux and UNIX systems, a process must be running with root
+                    privileges to listen on any port under 1024, including port 80. Proxying Tomcat
+                    through Apache means Tomcat can run as a reduced-privilege user, while Apache
+                    can bear the burden of root privileges. Further, as Apache is a native
+                    application, it can make system calls to safely drop root privileges once the
+                    port is open; a Java application like Tomcat cannot do this.</para>
+            </important>
+            <para>Be sure to specify the <code>URIEncoding="UTF-8"</code> attribute as above to
+                ensure that connection names, user names, etc. are properly received. If you will be
+                creating connections that have Cyrillic, Chinese, Japanese, etc. characters in the
+                names or parameter values, this attribute is required.</para>
+        </section>
+        <section>
+            <title>Configuring Apache and <package>mod_proxy</package></title>
+            <para>Configuring Apache to proxy HTTP requests requires using the
+                    <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
+                directives, which are provided by the <package>mod_proxy</package> module. These
+                directives describe how HTTP traffic should be routed to the web server behind the
+                proxy (Tomcat, in our case):</para>
+            <informalexample>
+                <programlisting>&lt;Location /guacamole/>
+    Order allow,deny
+    Allow from all
+    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
+    ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
+&lt;/Location></programlisting>
+            </informalexample>
+            <para>The most important thing in this entire section is the option
+                    <option>flushpackets=on</option>. Most proxies, including
+                    <package>mod_proxy</package>, will buffer all data sent over the connection,
+                waiting until the connection is closed before sending that data to the client. As
+                Guacamole's tunnel will stream data to the client over an open connection, buffering
+                this stream breaks Guacamole's communication.</para>
+            <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
+                    Guacamole will not work</emphasis>.</para>
+        </section>
+        <section xml:id="disable-tunnel-logging">
+            <title>Disable logging of tunnel requests</title>
+            <para>The Guacamole HTTP tunnel works by transferring a continuous stream of data over
+                multiple short-lived streams, each associated with a separate HTTP request. Each
+                HTTP request will be logged by Apache if you do not explicitly disable logging of
+                those requests.</para>
+            <para>Apache provides a means of matching URL patterns and setting environment variables
+                based on whether the URL matches. Logging can then be restricted to requests which
+                lack this environment variable:</para>
+            <informalexample>
+                <programlisting>SetEnvIf Request_URI "^<replaceable>/guacamole</replaceable>/tunnel" dontlog
+CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dontlog</programlisting>
+            </informalexample>
+            <para>There is little value in a log file filled with identical tunnel requests.</para>
+            <para>Note that if you are serving Guacamole under a path different from
+                    <uri>/guacamole/</uri>, you will need to change the value of
+                    <parameter>Request_URI</parameter> above accordingly.</para>
+        </section>
+        <section xml:id="change-web-app-path">
+            <title>Proxying under a different path</title>
+            <para>If you wish to serve Guacamole through Apache under a different path than it is
+                served under Tomcat, the configuration required for Apache will be slightly
+                different than the examples above due to cookies.</para>
+            <para>When a user logs in to Guacamole, a new session is created, and that session is
+                associated with a cookie sent to the user after they successfully log in. This
+                cookie is specific to the absolute path of the web application
+                    (<uri>/guacamole</uri>). If the path being used for Guacamole under Apache
+                differs from that used by Tomcat, the path in the cookie needs to be modified.
+                Thankfully, <package>mod_proxy</package> has a directive for this:
+                    <parameter>ProxyPassReverseCookiePath</parameter>.</para>
+            <informalexample>
+                <programlisting>&lt;Location /<replaceable>new-path/</replaceable>>
+    Order allow,deny
+    Allow from all
+    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
+    ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
+    ProxyPassReverseCookiePath /guacamole/ <replaceable>/new-path/</replaceable>
+&lt;/Location></programlisting>
+            </informalexample>
+            <para>The configuration shown above is similar to the configuration shown for generic
+                HTTP proxying, except that the additional
+                    <parameter>ProxyPassReverseCookiePath</parameter> directive is given,
+                instructing <package>mod_proxy</package> to update the cookie path, changing
+                    <uri>/guacamole/</uri> to <uri>/new-path/</uri>, the same path specified when
+                the location was declared.</para>
+        </section>
+    </section>
+</chapter>

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -79,12 +79,27 @@
     access_log off;
 }</programlisting>
             </informalexample>
+            <para>Here, <replaceable>HOSTNAME</replaceable> is the hostname or IP address of the
+                machine hosting your servlet container, and <replaceable>8080</replaceable> is the
+                port that servlet container is configured to use. You will need to replace these
+                values with the correct values for your server.</para>
+            <important>
+                <para><emphasis>Do not forget to specify "<code>proxy_buffering
+                        off</code>".</emphasis></para>
+                <para>Most proxies, including Nginx, will buffer all data sent over the connection,
+                    waiting until the connection is closed before sending that data to the client.
+                    As Guacamole's HTTP tunnel relies on streaming data to the client over an open
+                    connection, excessive buffering will effectively block Guacamole connections,
+                    rendering Guacamole useless.</para>
+                <para><emphasis>If the option "<code>proxy_buffering off</code>" is not specified,
+                        Guacamole may not work</emphasis>.</para>
+            </important>
         </section>
         <section>
             <title>Changing the path</title>
             <para>If you wish to serve Guacamole through Nginx under a path other than
-                    <uri>/guacamole/</uri>, the configuration will be altered slightly to take
-                cookies into account. Although Guacamole does not rely on receipt of cookies in
+                    <uri>/guacamole/</uri>, the configuration will need to be altered slightly to
+                take cookies into account. Although Guacamole does not rely on receipt of cookies in
                 general, cookies are required for the proper operation of the HTTP tunnel. If the
                 HTTP tunnel is used, and cookies cannot be set, users may be unexpectedly denied
                 access to their connections.</para>
@@ -133,6 +148,10 @@
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
 &lt;/Location></programlisting>
             </informalexample>
+            <para>Here, <replaceable>HOSTNAME</replaceable> is the hostname or IP address of the
+                machine hosting your servlet container, and <replaceable>8080</replaceable> is the
+                port that servlet container is configured to use. You will need to replace these
+                values with the correct values for your server.</para>
             <important>
                 <para><emphasis>Do not forget the <option>flushpackets=on</option>
                         option.</emphasis></para>
@@ -142,7 +161,7 @@
                     the client over an open connection, excessive buffering will effectively block
                     Guacamole connections, rendering Guacamole useless.</para>
                 <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
-                        Guacamole will not work</emphasis>.</para>
+                        Guacamole may not work</emphasis>.</para>
             </important>
         </section>
         <section>

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -2,33 +2,49 @@
 <chapter xml:id="proxying-guacamole" xmlns="http://docbook.org/ns/docbook" version="5.0"
     xml:lang="en" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Proxying Guacamole</title>
+    <para>Like most web applications, Guacamole can be placed behind a reverse proxy. For production
+        deployments of Guacamole, this is <emphasis>highly recommended</emphasis>. It provides
+        flexibility and, if your proxy is properly configured for SSL, encryption.</para>
+    <para>Proxying isolates privileged operations within native applications that can safely drop
+        those privileges when no longer needed, using Java only for unprivileged tasks. On Linux and
+        UNIX systems, a process must be running with root privileges to listen on any port under
+        1024, including the standard HTTP and HTTPS ports (80 and 443 respectively). If the servlet
+        container instead listens on a higher port, such as the default port 8080, it can run as a
+        reduced-privilege user, allowing the reverse proxy to bear the burden of root privileges. As
+        a native application, the reverse proxy can make system calls to safely drop root privileges
+        once the port is open; a Java application like Tomcat cannot do this.</para>
     <section>
-        <title>Configuring Tomcat for HTTP</title>
-        <para>Tomcat is most likely already configured to listen for HTTP connections on port 8080
-            as this is the default. In the case that the default HTTP connector has been disabled or
-            removed, you need to add a connector entry to
-            <filename>conf/server.xml</filename>:</para>
+        <title>Preparing your servlet container</title>
+        <para>Your servlet container is most likely already configured to listen for HTTP
+            connections on port 8080 as this is the default. If this is the case, and you can
+            already access Guacamole over port 8080 from a web browser, you need not make any
+            further changes to its configuration.</para>
+        <para>If you <emphasis>have</emphasis> changed this, perhaps with the intent of proxying
+            Guacamole over AJP, <emphasis>change it back</emphasis>. Using Guacamole over AJP is
+            unsupported as it is known to cause problems, namely:</para>
+        <orderedlist>
+            <listitem>
+                <para>WebSocket will not work over AJP, forcing Guacamole to fallback to HTTP,
+                    possibly resulting in reduced performance.</para>
+            </listitem>
+            <listitem>
+                <para>Apache 2.4.3 and older does not support the HTTP PATCH method over AJP,
+                    preventing the Guacamole management interface from functioning properly.</para>
+            </listitem>
+        </orderedlist>
+        <para>The connector entry within <filename>conf/server.xml</filename> should look like
+            this:</para>
         <informalexample>
             <programlisting>&lt;Connector port="8080" protocol="HTTP/1.1" 
            connectionTimeout="20000"
            URIEncoding="UTF-8"
            redirectPort="8443" /></programlisting>
         </informalexample>
-        <important>
-            <para>If you want to edit or add this connector just to change the port used by Tomcat
-                to port 80, you should consider simply proxying the original port through Apache or
-                Nginx instead.</para>
-            <para>On Linux and UNIX systems, a process must be running with root privileges to
-                listen on any port under 1024, including port 80. If Tomcat does not need to
-                directly listen on port 80, it can run as a reduced-privilege user, allowing the
-                reverse proxy to bear the burden of root privileges. As a native application, the
-                reverse proxy can make system calls to safely drop root privileges once the port is
-                open; a Java application like Tomcat cannot do this.</para>
-        </important>
         <para>Be sure to specify the <code>URIEncoding="UTF-8"</code> attribute as above to ensure
-            that connection names, user names, etc. are properly received. If you will be creating
-            connections that have Cyrillic, Chinese, Japanese, etc. characters in the names or
-            parameter values, this attribute is required.</para>
+            that connection names, user names, etc. are properly received by the web application. If
+            you will be creating connections that have Cyrillic, Chinese, Japanese, or other
+            non-Latin characters in their names or parameter values, this attribute is
+            required.</para>
     </section>
     <section xml:id="nginx">
         <title>Nginx</title>
@@ -36,14 +52,21 @@
                 xl:href="http://nginx.com/blog/websocket-nginx/">since version 1.3</link>, and so is
             an excellent choice for proxying Guacamole if you aren't already using another proxy
             like Apache.</para>
-        <informalexample>
-            <programlisting>map $http_upgrade $connection_upgrade {
+        <section>
+            <title>Configuring WebSocket</title>
+            <para/>
+            <informalexample>
+                <programlisting>map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
 }</programlisting>
-        </informalexample>
-        <informalexample>
-            <programlisting>location /guacamole/ {
+            </informalexample>
+        </section>
+        <section>
+            <title>Proxying Guacamole</title>
+            <para/>
+            <informalexample>
+                <programlisting>location /guacamole/ {
     proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
     proxy_buffering off;
     proxy_http_version 1.1;
@@ -52,9 +75,13 @@
     proxy_set_header Connection $connection_upgrade;
     access_log off;
 }</programlisting>
-        </informalexample>
-        <informalexample>
-            <programlisting>location /<replaceable>new-path/</replaceable> {
+            </informalexample>
+        </section>
+        <section>
+            <title>Changing the path</title>
+            <para/>
+            <informalexample>
+                <programlisting>location /<replaceable>new-path/</replaceable> {
     proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
     proxy_buffering off;
     proxy_http_version 1.1;
@@ -64,60 +91,50 @@
     proxy_cookie_path /guacamole/ /<replaceable>new-path/</replaceable>;
     access_log off;
 }</programlisting>
-        </informalexample>
+            </informalexample>
+        </section>
     </section>
     <section xml:id="mod-proxy">
         <title>Apache and <package>mod_proxy</package></title>
-        <para>Many users end up serving Guacamole through Apache using <package>mod_proxy</package>,
-            a module which allows Apache to be used as a reverse proxy for other servers, such as a
-            servlet container like Tomcat. The need to do this can range from simply wanting to use
-            port 80, to sharing an SSL certificate with your web server, to security and load
-            balancing.</para>
-        <para>By default, servlet containers like Tomcat listen on port 8080, which is not the
-            standard HTTP port (port 80). If you are using Linux (or another UNIX system), only the
-            root user can run programs which listen on ports less than 1024, including port 80, and
-            reducing the number of programs that run with root privileges is always a good
-            idea.</para>
-        <para>If you have an SSL certificate, it may make sense to use Apache for SSL processing and
-            save Tomcat from having to do this itself, which may not be as efficient. Again, this
-            also makes sense from the perspective of security, as it reduces the number of users
-            that require read access to identifying certificates.</para>
-        <para>While load balancing won't be covered here, if you are expecting large numbers of
-            users, balancing the load on Tomcat across multiple Tomcat instances is a common
-            solution.</para>
-        <important>
-            <para>Beware that, like the rest of this manual, we assume here that you are using
-                Tomcat. If you are using a different servlet container, the same principles apply,
-                and the Apache configuration examples will still be valid.</para>
-        </important>
-        <para>Configuring Apache to proxy HTTP requests requires using the
-                <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
-            directives, which are provided by the <package>mod_proxy</package> module. These
-            directives describe how HTTP traffic should be routed to the web server behind the proxy
-            (Tomcat, in our case):</para>
-        <informalexample>
-            <programlisting>&lt;Location /guacamole/>
+        <para>Apache supports reverse proxy configurations through <package>mod_proxy</package>.
+            Apache 2.4.5 and later also support proxying of WebSocket through a sub-module called
+                <package>mod_proxy_wstunnel</package>. Both of these modules will need to be enabled
+            for proxying of Guacamole to work properly.</para>
+        <para>Lacking <package>mod_proxy_wstunnel</package>, it is still possible to proxy
+            Guacamole, but Guacamole will be unable to use WebSocket. It will instead fallback to
+            using the HTTP tunnel, resulting in reduced performance.</para>
+        <section>
+            <title>Proxying Guacamole</title>
+            <para>Configuring Apache to proxy HTTP requests requires using the
+                    <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
+                directives, which are provided by the <package>mod_proxy</package> module. These
+                directives describe how HTTP traffic should be routed to the web server behind the
+                proxy:</para>
+            <informalexample>
+                <programlisting>&lt;Location /guacamole/>
     Order allow,deny
     Allow from all
     ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ flushpackets=on
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
 &lt;/Location></programlisting>
-        </informalexample>
-        <para>The most important thing in this entire section is the option
-                <option>flushpackets=on</option>. Most proxies, including
-                <package>mod_proxy</package>, will buffer all data sent over the connection, waiting
-            until the connection is closed before sending that data to the client. As Guacamole's
-            tunnel will stream data to the client over an open connection, buffering this stream
-            breaks Guacamole's communication.</para>
-        <para><emphasis>If the option <option>flushpackets=on</option> is not specified, Guacamole
-                will not work</emphasis>.</para>
+            </informalexample>
+            <para>The most important thing in this entire section is the option
+                    <option>flushpackets=on</option>. Most proxies, including
+                    <package>mod_proxy</package>, will buffer all data sent over the connection,
+                waiting until the connection is closed before sending that data to the client. As
+                Guacamole's tunnel will stream data to the client over an open connection, buffering
+                this stream breaks Guacamole's communication.</para>
+            <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
+                    Guacamole will not work</emphasis>.</para>
+        </section>
         <section>
-            <title>WebSocket</title>
+            <title>Proxying the WebSocket tunnel</title>
             <para>Apache will not automatically proxy WebSocket connections, but you can proxy them
                 separately with Apache 2.4.5 and later using <package>mod_proxy_wstunnel</package>.
                 After enabling <package>mod_proxy_wstunnel</package> a secondary
                     <code>Location</code> section can be added which explicitly proxies the
-                Guacamole WebSocket tunnel, located at <uri>/websocket-tunnel</uri>:</para>
+                Guacamole WebSocket tunnel, located at
+                <uri>/guacamole/websocket-tunnel</uri>:</para>
             <informalexample>
                 <programlisting>&lt;Location /guacamole/websocket-tunnel>
     Order allow,deny
@@ -129,39 +146,29 @@
             <para>Lacking this, Guacamole will still work by using normal HTTP, but network latency
                 will be more pronounced with respect to user input, and performance may be
                 lower.</para>
-        </section>
-        <section xml:id="disable-tunnel-logging">
-            <title>Disable logging of HTTP tunnel requests</title>
-            <para>If WebSocket is unavailable, Guacamole will fallback to using an HTTP-based
-                tunnel. The Guacamole HTTP tunnel works by transferring a continuous stream of data
-                over multiple short-lived streams, each associated with a separate HTTP
-                request.</para>
-            <para>Apache will log each of these requests by default, resulting in a rather bloated
-                access log. There is little value in a log file filled with identical tunnel
-                requests, so it is recommended to explicitly disable logging of those requests.
-                Apache does provide a means of matching URL patterns and setting environment
-                variables based on whether the URL matches. Logging can then be restricted to
-                requests which lack this environment variable:</para>
-            <informalexample>
-                <programlisting>SetEnvIf Request_URI "^<replaceable>/guacamole</replaceable>/tunnel" dontlog
-CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dontlog</programlisting>
-            </informalexample>
-            <para>Note that if you are serving Guacamole under a path different from
-                    <uri>/guacamole/</uri>, you will need to change the value of
-                    <parameter>Request_URI</parameter> above accordingly.</para>
+            <important>
+                <para>The <code>Location</code> section for <uri>/guacamole/websocket-tunnel</uri>
+                    must be placed after the <code>Location</code> section for the rest of
+                    Guacamole.</para>
+                <para>Apache evaluates all Location sections, giving priority to the last section
+                    that matches. If the <uri>/guacamole/websocket-tunnel</uri> section comes first,
+                    the section for <uri>/guacamole/</uri> will match instead, and WebSocket will
+                    not be proxied correctly.</para>
+            </important>
         </section>
         <section xml:id="change-web-app-path">
-            <title>Proxying under a different path</title>
-            <para>If you wish to serve Guacamole through Apache under a different path than it is
-                served under Tomcat, the configuration required for Apache will be slightly
+            <title>Changing the path</title>
+            <para>If you wish to serve Guacamole through Apache under a path other than
+                    <uri>/guacamole/</uri>, the configuration required for Apache will be slightly
                 different than the examples above due to cookies.</para>
-            <para>When a user logs in to Guacamole, a new session is created, and that session is
-                associated with a cookie sent to the user after they successfully log in. This
-                cookie is specific to the absolute path of the web application
-                    (<uri>/guacamole</uri>). If the path being used for Guacamole under Apache
-                differs from that used by Tomcat, the path in the cookie needs to be modified.
-                Thankfully, <package>mod_proxy</package> has a directive for this:
-                    <parameter>ProxyPassReverseCookiePath</parameter>.</para>
+            <para>Guacamole does not rely on receipt of cookies for tracking whether a user is
+                logged in, but cookies are required for the proper operation of the HTTP tunnel. If
+                the HTTP tunnel is used, and cookies cannot be set, users will be unexpectedly
+                denied access to connections they legitimately should have access to.</para>
+            <para>Cookies are set using the absolute path of the web application
+                    (<uri>/guacamole/</uri>). If this path differs from that used by Apache, the
+                path in the cookie needs to be modified using the
+                    <parameter>ProxyPassReverseCookiePath</parameter> directive:</para>
             <informalexample>
                 <programlisting>&lt;Location /<replaceable>new-path/</replaceable>>
     Order allow,deny
@@ -169,22 +176,37 @@ CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dont
     ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ flushpackets=on
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
     ProxyPassReverseCookiePath /guacamole/ /<replaceable>new-path/</replaceable>
-&lt;/Location></programlisting>
-            </informalexample>
-            <informalexample>
-                <programlisting>&lt;Location /<replaceable>new-path</replaceable>/websocket-tunnel>
+&lt;/Location>
+
+&lt;Location /<replaceable>new-path</replaceable>/websocket-tunnel>
     Order allow,deny
     Allow from all
     ProxyPass ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
     ProxyPassReverse ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
 &lt;/Location></programlisting>
             </informalexample>
-            <para>The configuration shown above is similar to the configuration shown for generic
-                HTTP proxying, except that the additional
-                    <parameter>ProxyPassReverseCookiePath</parameter> directive is given,
-                instructing <package>mod_proxy</package> to update the cookie path, changing
-                    <uri>/guacamole/</uri> to <uri>/new-path/</uri>, the same path specified when
-                the location was declared.</para>
+            <para>This directive is not needed for the WebSocket section, as it is not applicable.
+                Cookies are only used by Guacamole within the HTTP tunnel.</para>
+        </section>
+        <section xml:id="disable-tunnel-logging">
+            <title>Disabling logging of tunnel requests</title>
+            <para>If WebSocket is unavailable, Guacamole will fallback to using an HTTP-based
+                tunnel. The Guacamole HTTP tunnel works by transferring a continuous stream of data
+                over multiple short-lived streams, each associated with a separate HTTP request. By
+                default, Apache will log each of these requests, resulting in a rather bloated
+                access log.</para>
+            <para>There is little value in a log file filled with identical tunnel requests, so it
+                is recommended to explicitly disable logging of those requests. Apache does provide
+                a means of matching URL patterns and setting environment variables based on whether
+                the URL matches. Logging can then be restricted to requests which lack this
+                environment variable:</para>
+            <informalexample>
+                <programlisting>SetEnvIf Request_URI "^<replaceable>/guacamole</replaceable>/tunnel" dontlog
+CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dontlog</programlisting>
+            </informalexample>
+            <para>Note that if you are serving Guacamole under a path different from
+                    <uri>/guacamole/</uri>, you will need to change the value of
+                    <parameter>Request_URI</parameter> above accordingly.</para>
         </section>
     </section>
 </chapter>

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -48,10 +48,10 @@
     </section>
     <section xml:id="nginx">
         <title>Nginx</title>
-        <para>Nginx supports WebSocket out-of-the-box <link
-                xl:href="http://nginx.com/blog/websocket-nginx/">since version 1.3</link>, and so is
-            an excellent choice for proxying Guacamole if you aren't already using another proxy
-            like Apache.</para>
+        <para>Nginx can be used as a reverse proxy, and supports WebSocket out-of-the-box <link
+                xl:href="http://nginx.com/blog/websocket-nginx/">since version 1.3</link>. Both
+            Apache and Nginx require some additional configuration for proxying of WebSocket to work
+            properly.</para>
         <section>
             <title>Configuring WebSocket</title>
             <para/>
@@ -96,10 +96,13 @@
     </section>
     <section xml:id="mod-proxy">
         <title>Apache and <package>mod_proxy</package></title>
-        <para>Apache supports reverse proxy configurations through <package>mod_proxy</package>.
-            Apache 2.4.5 and later also support proxying of WebSocket through a sub-module called
-                <package>mod_proxy_wstunnel</package>. Both of these modules will need to be enabled
-            for proxying of Guacamole to work properly.</para>
+        <para>Apache supports reverse proxy configurations through <link
+                xl:href="http://httpd.apache.org/docs/2.4/mod/mod_proxy.html"
+                    ><package>mod_proxy</package></link>. Apache 2.4.5 and later also support
+            proxying of WebSocket through a sub-module called <link
+                xl:href="http://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html"
+                    ><package>mod_proxy_wstunnel</package></link>. Both of these modules will need
+            to be enabled for proxying of Guacamole to work properly.</para>
         <para>Lacking <package>mod_proxy_wstunnel</package>, it is still possible to proxy
             Guacamole, but Guacamole will be unable to use WebSocket. It will instead fallback to
             using the HTTP tunnel, resulting in reduced performance.</para>
@@ -118,14 +121,17 @@
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
 &lt;/Location></programlisting>
             </informalexample>
-            <para>The most important thing in this entire section is the option
-                    <option>flushpackets=on</option>. Most proxies, including
-                    <package>mod_proxy</package>, will buffer all data sent over the connection,
-                waiting until the connection is closed before sending that data to the client. As
-                Guacamole's tunnel will stream data to the client over an open connection, buffering
-                this stream breaks Guacamole's communication.</para>
-            <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
-                    Guacamole will not work</emphasis>.</para>
+            <important>
+                <para><emphasis>Do not forget the <option>flushpackets=on</option>
+                        option.</emphasis></para>
+                <para>Most proxies, including <package>mod_proxy</package>, will buffer all data
+                    sent over the connection, waiting until the connection is closed before sending
+                    that data to the client. As Guacamole's HTTP tunnel relies on streaming data to
+                    the client over an open connection, excessive buffering will effectively block
+                    Guacamole connections, rendering Guacamole useless.</para>
+                <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
+                        Guacamole will not work</emphasis>.</para>
+            </important>
         </section>
         <section>
             <title>Proxying the WebSocket tunnel</title>

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -3,32 +3,66 @@
     xml:lang="en" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
     <title>Proxying Guacamole</title>
     <section>
+        <title>Configuring Tomcat for HTTP</title>
+        <para>Tomcat is most likely already configured to listen for HTTP connections on port 8080
+            as this is the default. In the case that the default HTTP connector has been disabled or
+            removed, you need to add a connector entry to
+            <filename>conf/server.xml</filename>:</para>
+        <informalexample>
+            <programlisting>&lt;Connector port="8080" protocol="HTTP/1.1" 
+           connectionTimeout="20000"
+           URIEncoding="UTF-8"
+           redirectPort="8443" /></programlisting>
+        </informalexample>
+        <important>
+            <para>If you want to edit or add this connector just to change the port used by Tomcat
+                to port 80, you should consider simply proxying the original port through Apache or
+                Nginx instead.</para>
+            <para>On Linux and UNIX systems, a process must be running with root privileges to
+                listen on any port under 1024, including port 80. If Tomcat does not need to
+                directly listen on port 80, it can run as a reduced-privilege user, allowing the
+                reverse proxy to bear the burden of root privileges. As a native application, the
+                reverse proxy can make system calls to safely drop root privileges once the port is
+                open; a Java application like Tomcat cannot do this.</para>
+        </important>
+        <para>Be sure to specify the <code>URIEncoding="UTF-8"</code> attribute as above to ensure
+            that connection names, user names, etc. are properly received. If you will be creating
+            connections that have Cyrillic, Chinese, Japanese, etc. characters in the names or
+            parameter values, this attribute is required.</para>
+    </section>
+    <section xml:id="nginx">
         <title>Nginx</title>
+        <para>Nginx supports WebSocket out-of-the-box <link
+                xl:href="http://nginx.com/blog/websocket-nginx/">since version 1.3</link>, and so is
+            an excellent choice for proxying Guacamole if you aren't already using another proxy
+            like Apache.</para>
         <informalexample>
             <programlisting>map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
-}
-
-server {
-
-    listen 443;
-
-    location / {
-        proxy_pass http://localhost:8080/guacamole/;
-        proxy_buffering off;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_cookie_path /guacamole/ /;
-        access_log off;
-    }
-
-    ssl on;
-    ssl_certificate     /path/to/certificate.crt;
-    ssl_certificate_key /path/to/private_key.key;
-
+}</programlisting>
+        </informalexample>
+        <informalexample>
+            <programlisting>location /guacamole/ {
+    proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
+    proxy_buffering off;
+    proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    access_log off;
+}</programlisting>
+        </informalexample>
+        <informalexample>
+            <programlisting>location /<replaceable>new-path/</replaceable> {
+    proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
+    proxy_buffering off;
+    proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_cookie_path /guacamole/ /<replaceable>new-path/</replaceable>;
+    access_log off;
 }</programlisting>
         </informalexample>
     </section>
@@ -56,71 +90,62 @@ server {
                 Tomcat. If you are using a different servlet container, the same principles apply,
                 and the Apache configuration examples will still be valid.</para>
         </important>
-        <section>
-            <title>Configuring Tomcat for HTTP</title>
-            <para>Tomcat is most likely already configured to listen for HTTP connections on port
-                8080 as this is the default. In the case that the default HTTP connector has been
-                disabled or removed, you need to add a connector entry to
-                    <filename>conf/server.xml</filename>:</para>
-            <informalexample>
-                <programlisting>&lt;Connector port="8080" protocol="HTTP/1.1" 
-           connectionTimeout="20000"
-           URIEncoding="UTF-8"
-           redirectPort="8443" /></programlisting>
-            </informalexample>
-            <important>
-                <para>If you want to edit or add this connector just to change the port used by
-                    Tomcat to port 80, you should consider simply proxying the original port through
-                    Apache instead. On Linux and UNIX systems, a process must be running with root
-                    privileges to listen on any port under 1024, including port 80. Proxying Tomcat
-                    through Apache means Tomcat can run as a reduced-privilege user, while Apache
-                    can bear the burden of root privileges. Further, as Apache is a native
-                    application, it can make system calls to safely drop root privileges once the
-                    port is open; a Java application like Tomcat cannot do this.</para>
-            </important>
-            <para>Be sure to specify the <code>URIEncoding="UTF-8"</code> attribute as above to
-                ensure that connection names, user names, etc. are properly received. If you will be
-                creating connections that have Cyrillic, Chinese, Japanese, etc. characters in the
-                names or parameter values, this attribute is required.</para>
-        </section>
-        <section>
-            <title>Configuring Apache and <package>mod_proxy</package></title>
-            <para>Configuring Apache to proxy HTTP requests requires using the
-                    <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
-                directives, which are provided by the <package>mod_proxy</package> module. These
-                directives describe how HTTP traffic should be routed to the web server behind the
-                proxy (Tomcat, in our case):</para>
-            <informalexample>
-                <programlisting>&lt;Location /guacamole/>
+        <para>Configuring Apache to proxy HTTP requests requires using the
+                <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
+            directives, which are provided by the <package>mod_proxy</package> module. These
+            directives describe how HTTP traffic should be routed to the web server behind the proxy
+            (Tomcat, in our case):</para>
+        <informalexample>
+            <programlisting>&lt;Location /guacamole/>
     Order allow,deny
     Allow from all
-    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
+    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ flushpackets=on
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
 &lt;/Location></programlisting>
+        </informalexample>
+        <para>The most important thing in this entire section is the option
+                <option>flushpackets=on</option>. Most proxies, including
+                <package>mod_proxy</package>, will buffer all data sent over the connection, waiting
+            until the connection is closed before sending that data to the client. As Guacamole's
+            tunnel will stream data to the client over an open connection, buffering this stream
+            breaks Guacamole's communication.</para>
+        <para><emphasis>If the option <option>flushpackets=on</option> is not specified, Guacamole
+                will not work</emphasis>.</para>
+        <section>
+            <title>WebSocket</title>
+            <para>Apache will not automatically proxy WebSocket connections, but you can proxy them
+                separately with Apache 2.4.5 and later using <package>mod_proxy_wstunnel</package>.
+                After enabling <package>mod_proxy_wstunnel</package> a secondary
+                    <code>Location</code> section can be added which explicitly proxies the
+                Guacamole WebSocket tunnel, located at <uri>/websocket-tunnel</uri>:</para>
+            <informalexample>
+                <programlisting>&lt;Location /guacamole/websocket-tunnel>
+    Order allow,deny
+    Allow from all
+    ProxyPass ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
+    ProxyPassReverse ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
+&lt;/Location></programlisting>
             </informalexample>
-            <para>The most important thing in this entire section is the option
-                    <option>flushpackets=on</option>. Most proxies, including
-                    <package>mod_proxy</package>, will buffer all data sent over the connection,
-                waiting until the connection is closed before sending that data to the client. As
-                Guacamole's tunnel will stream data to the client over an open connection, buffering
-                this stream breaks Guacamole's communication.</para>
-            <para><emphasis>If the option <option>flushpackets=on</option> is not specified,
-                    Guacamole will not work</emphasis>.</para>
+            <para>Lacking this, Guacamole will still work by using normal HTTP, but network latency
+                will be more pronounced with respect to user input, and performance may be
+                lower.</para>
         </section>
         <section xml:id="disable-tunnel-logging">
-            <title>Disable logging of tunnel requests</title>
-            <para>The Guacamole HTTP tunnel works by transferring a continuous stream of data over
-                multiple short-lived streams, each associated with a separate HTTP request. Each
-                HTTP request will be logged by Apache if you do not explicitly disable logging of
-                those requests.</para>
-            <para>Apache provides a means of matching URL patterns and setting environment variables
-                based on whether the URL matches. Logging can then be restricted to requests which
-                lack this environment variable:</para>
+            <title>Disable logging of HTTP tunnel requests</title>
+            <para>If WebSocket is unavailable, Guacamole will fallback to using an HTTP-based
+                tunnel. The Guacamole HTTP tunnel works by transferring a continuous stream of data
+                over multiple short-lived streams, each associated with a separate HTTP
+                request.</para>
+            <para>Apache will log each of these requests by default, resulting in a rather bloated
+                access log. There is little value in a log file filled with identical tunnel
+                requests, so it is recommended to explicitly disable logging of those requests.
+                Apache does provide a means of matching URL patterns and setting environment
+                variables based on whether the URL matches. Logging can then be restricted to
+                requests which lack this environment variable:</para>
             <informalexample>
                 <programlisting>SetEnvIf Request_URI "^<replaceable>/guacamole</replaceable>/tunnel" dontlog
 CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dontlog</programlisting>
             </informalexample>
-            <para>There is little value in a log file filled with identical tunnel requests.</para>
             <para>Note that if you are serving Guacamole under a path different from
                     <uri>/guacamole/</uri>, you will need to change the value of
                     <parameter>Request_URI</parameter> above accordingly.</para>
@@ -141,9 +166,17 @@ CustomLog  <replaceable>/var/log/apache2/guac.log</replaceable> common env=!dont
                 <programlisting>&lt;Location /<replaceable>new-path/</replaceable>>
     Order allow,deny
     Allow from all
-    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ max=20 flushpackets=on
+    ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ flushpackets=on
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
-    ProxyPassReverseCookiePath /guacamole/ <replaceable>/new-path/</replaceable>
+    ProxyPassReverseCookiePath /guacamole/ /<replaceable>new-path/</replaceable>
+&lt;/Location></programlisting>
+            </informalexample>
+            <informalexample>
+                <programlisting>&lt;Location /<replaceable>new-path</replaceable>/websocket-tunnel>
+    Order allow,deny
+    Allow from all
+    ProxyPass ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
+    ProxyPassReverse ws://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/websocket-tunnel
 &lt;/Location></programlisting>
             </informalexample>
             <para>The configuration shown above is similar to the configuration shown for generic

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -13,7 +13,7 @@
         reduced-privilege user, allowing the reverse proxy to bear the burden of root privileges. As
         a native application, the reverse proxy can make system calls to safely drop root privileges
         once the port is open; a Java application like Tomcat cannot do this.</para>
-    <section>
+    <section xml:id="preparing-servlet-container">
         <title>Preparing your servlet container</title>
         <para>Your servlet container is most likely already configured to listen for HTTP
             connections on port 8080 as this is the default. If this is the case, and you can
@@ -52,7 +52,7 @@
                 xl:href="http://nginx.com/blog/websocket-nginx/">since version 1.3</link>. Both
             Apache and Nginx require some additional configuration for proxying of WebSocket to work
             properly.</para>
-        <section>
+        <section xml:id="proxying-with-nginx">
             <title>Proxying Guacamole</title>
             <para>Nginx does support WebSocket for proxying, but requires that the "Connection" and
                 "Upgrade" HTTP headers are set explicitly due to the nature of the WebSocket
@@ -95,7 +95,7 @@
                         Guacamole may not work</emphasis>.</para>
             </important>
         </section>
-        <section>
+        <section xml:id="changing-path-with-nginx">
             <title>Changing the path</title>
             <para>If you wish to serve Guacamole through Nginx under a path other than
                     <uri>/guacamole/</uri>, the configuration will need to be altered slightly to
@@ -121,7 +121,7 @@
             </informalexample>
         </section>
     </section>
-    <section xml:id="mod-proxy">
+    <section xml:id="apache">
         <title>Apache and <package>mod_proxy</package></title>
         <para>Apache supports reverse proxy configurations through <link
                 xl:href="http://httpd.apache.org/docs/2.4/mod/mod_proxy.html"
@@ -133,7 +133,7 @@
         <para>Lacking <package>mod_proxy_wstunnel</package>, it is still possible to proxy
             Guacamole, but Guacamole will be unable to use WebSocket. It will instead fallback to
             using the HTTP tunnel, resulting in reduced performance.</para>
-        <section>
+        <section xml:id="proxying-with-apache">
             <title>Proxying Guacamole</title>
             <para>Configuring Apache to proxy HTTP requests requires using the
                     <parameter>ProxyPass</parameter> and <parameter>ProxyPassReverse</parameter>
@@ -164,7 +164,7 @@
                         Guacamole may not work</emphasis>.</para>
             </important>
         </section>
-        <section>
+        <section xml:id="websocket-and-apache">
             <title>Proxying the WebSocket tunnel</title>
             <para>Apache will not automatically proxy WebSocket connections, but you can proxy them
                 separately with Apache 2.4.5 and later using <package>mod_proxy_wstunnel</package>.
@@ -193,7 +193,7 @@
                     not be proxied correctly.</para>
             </important>
         </section>
-        <section xml:id="change-web-app-path">
+        <section xml:id="changing-path-with-apache">
             <title>Changing the path</title>
             <para>If you wish to serve Guacamole through Apache under a path other than
                     <uri>/guacamole/</uri>, the configuration required for Apache will be slightly

--- a/src/chapters/reverse-proxy.xml
+++ b/src/chapters/reverse-proxy.xml
@@ -53,18 +53,21 @@
             Apache and Nginx require some additional configuration for proxying of WebSocket to work
             properly.</para>
         <section>
-            <title>Configuring WebSocket</title>
-            <para/>
-            <informalexample>
-                <programlisting>map $http_upgrade $connection_upgrade {
-    default upgrade;
-    ''      close;
-}</programlisting>
-            </informalexample>
-        </section>
-        <section>
             <title>Proxying Guacamole</title>
-            <para/>
+            <para>Nginx does support WebSocket for proxying, but requires that the "Connection" and
+                "Upgrade" HTTP headers are set explicitly due to the nature of the WebSocket
+                protocol. From the Nginx documentation:</para>
+            <blockquote>
+                <para>NGINX supports WebSocket by allowing a tunnel to be set up between a client
+                    and a back-end server. For NGINX to send the Upgrade request from the client to
+                    the back-end server, Upgrade and Connection headers must be set explicitly.
+                    ...</para>
+            </blockquote>
+            <para>The proxy configuration belongs within a dedicated <link
+                    xl:href="http://nginx.org/en/docs/http/ngx_http_core_module.html#location"
+                        ><code>location</code></link> block, declaring the backend hosting Guacamole
+                and explicitly specifying the "Connection" and "Upgrade" headers mentioned
+                earlier:</para>
             <informalexample>
                 <programlisting>location /guacamole/ {
     proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
@@ -72,14 +75,23 @@
     proxy_http_version 1.1;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Connection $http_connection;
     access_log off;
 }</programlisting>
             </informalexample>
         </section>
         <section>
             <title>Changing the path</title>
-            <para/>
+            <para>If you wish to serve Guacamole through Nginx under a path other than
+                    <uri>/guacamole/</uri>, the configuration will be altered slightly to take
+                cookies into account. Although Guacamole does not rely on receipt of cookies in
+                general, cookies are required for the proper operation of the HTTP tunnel. If the
+                HTTP tunnel is used, and cookies cannot be set, users may be unexpectedly denied
+                access to their connections.</para>
+            <para>Regardless of the location specified for the proxy, cookies set by Guacamole will
+                be set using its own absolute path within the backend (<uri>/guacamole/</uri>). If
+                this path differs from that used by Nginx, the path in the cookie needs to be
+                modified using <code>proxy_cookie_path</code>:</para>
             <informalexample>
                 <programlisting>location /<replaceable>new-path/</replaceable> {
     proxy_pass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/;
@@ -87,8 +99,8 @@
     proxy_http_version 1.1;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_cookie_path /guacamole/ /<replaceable>new-path/</replaceable>;
+    proxy_set_header Connection $http_connection;
+    <emphasis>proxy_cookie_path /guacamole/ /<replaceable>new-path/</replaceable>;</emphasis>
     access_log off;
 }</programlisting>
             </informalexample>
@@ -181,7 +193,7 @@
     Allow from all
     ProxyPass http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/ flushpackets=on
     ProxyPassReverse http://<replaceable>HOSTNAME</replaceable>:<replaceable>8080</replaceable>/guacamole/
-    ProxyPassReverseCookiePath /guacamole/ /<replaceable>new-path/</replaceable>
+    <emphasis>ProxyPassReverseCookiePath /guacamole/ /<replaceable>new-path/</replaceable></emphasis>
 &lt;/Location>
 
 &lt;Location /<replaceable>new-path</replaceable>/websocket-tunnel>

--- a/src/gug.css
+++ b/src/gug.css
@@ -100,6 +100,7 @@ div#content {
 
 .table-contents td, .table-contents th,
 .informaltable td, .informaltable th {
+    border: 1px solid #BCBCBC;
     padding: 0.5em;
     min-width: 1.5in;
 }

--- a/src/gug.css
+++ b/src/gug.css
@@ -50,6 +50,19 @@ div#content {
     padding: 1em;
 }
 
+.replaceable {
+    color: #008;
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    font-style: normal;
+    padding: 0 0.25em;
+}
+
+pre .emphasis em {
+    font-style: normal;
+    font-weight: bold;
+}
+
 .book .titlepage {
     text-align: center;
     padding: 2em;
@@ -131,6 +144,13 @@ blockquote {
     padding: 1px 1em;
     font-style: oblique;
     color: rgba(0, 0, 0, 0.75);
+}
+
+div.important {
+    background: #FFFFE8;
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    padding: 0 1em;
+    margin: 2em;
 }
 
 /* Printable styles */

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -155,6 +155,7 @@
         <xi:include href="chapters/architecture.xml"/>
         <xi:include href="chapters/installing.xml"/>
         <xi:include href="chapters/docker.xml"/>
+        <xi:include href="chapters/reverse-proxy.xml"/>
         <xi:include href="chapters/configuring.xml"/>
         <xi:include href="chapters/jdbc-auth.xml"/>
         <xi:include href="chapters/ldap-auth.xml"/>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -154,6 +154,7 @@
         <title>User's Guide</title>
         <xi:include href="chapters/architecture.xml"/>
         <xi:include href="chapters/installing.xml"/>
+        <xi:include href="chapters/docker.xml"/>
         <xi:include href="chapters/configuring.xml"/>
         <xi:include href="chapters/jdbc-auth.xml"/>
         <xi:include href="chapters/ldap-auth.xml"/>

--- a/src/site.xslt
+++ b/src/site.xslt
@@ -36,6 +36,9 @@
     <!-- Custom stylesheet -->
     <xsl:param name="html.stylesheet" select="'gug.css'"/>
 
+    <!-- No inline styles for admonitions -->
+    <xsl:param name="admon.style"></xsl:param>
+
     <!-- Chunk only at chapter level -->
     <xsl:param name="chunk.section.depth" select="0"/>
 


### PR DESCRIPTION
This change reorganizes the manual, adding a new chapter documenting installation of Guacamole under Docker, and splitting the proxy documentation into its own chapter.

I've also added documentation describing proxying via Nginx (we previously only described Apache), and proxying WebSocket with Apache (we previously left this out). Lacking these changes, anyone proxying Guacamole will end up without WebSocket.
