### PR TITLE
GUAC-1172: Document new object instructions.

### DIFF
--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -314,20 +314,21 @@
                 child extends beyond the parents bounds, it will be clipped.</para>
         </section>
     </section>
-    <section xml:id="guacamole-audio-video">
-        <title>Multimedia streaming and pipes</title>
+    <section xml:id="guacamole-protocol-streaming">
+        <title>Streams and objects</title>
         <para>Guacamole supports transfer of both audio and video data, as well as files and
-            arbitrary named pipes. Streams can be allocated with audio or video instructions for the
-            sake of playing media, with file instructions for file transfer, or with "pipe"
-            instructions for transfer or abtrary data between client and server.</para>
+            arbitrary named pipes. Streams can be allocated directly with audio or video
+            instructions for the sake of playing media, with file instructions for file transfer,
+            with "pipe" instructions for transfer of arbitrary data between client and server, or
+            exposed as structured sets of named streams known as "objects".</para>
         <para>By the nature of the Guacamole protocol, you must know the duration of the audio or
             video data before it is sent. This is because sequential playing of multiple audio or
             video chunks must be carefully timed by the client to avoid gaps in playback. Even a gap
             of only one millisecond will produce an audible "click" in audio playback.</para>
         <para>As far as audio and video are concerned, variance in chunk size gives a trade-off
             between responsiveness and perceived quality. Larger chunks will provide smoother audio
-            and video, but have noticable lag compared to smaller chunks. Smaller chunks provide
-            less lag, but may produce noticable clicking or stutter if the timing of each chunk is
+            and video, but have noticeable lag compared to smaller chunks. Smaller chunks provide
+            less lag, but may produce noticeable clicking or stutter if the timing of each chunk is
             not perfect.</para>
     </section>
     <section xml:id="guacamole-protocol-events">

--- a/src/references/instructions/server/object/body.xml
+++ b/src/references/instructions/server/object/body.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="body-object-instruction" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>body</title>
+    <indexterm>
+        <primary>body</primary>
+    </indexterm>
+    <para>Allocates a new stream, associating it with the name of a stream previously requested by a
+        get instruction. The contents of the stream will be sent later with blob instructions. The
+        full size of the stream need not be known ahead of time.</para>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>object</parameter></term>
+            <listitem>
+                <para>The index of the object associated with this stream.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>stream</parameter></term>
+            <listitem>
+                <para>The index of the stream to allocate.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>mimetype</parameter></term>
+            <listitem>
+                <para>The mimetype of the data being sent.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>name</parameter></term>
+            <listitem>
+                <para>The name of the stream associated with the object.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+</section>

--- a/src/references/instructions/server/object/filesystem.xml
+++ b/src/references/instructions/server/object/filesystem.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="filesystem-object-instruction" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>filesystem</title>
+    <indexterm>
+        <primary>filesystem</primary>
+    </indexterm>
+    <para>Allocates a new object, associating it with the given arbitrary filesystem metadata. The
+        contents of files and directories within the filesystem will later be sent along streams
+        requested with get instructions or created with put instructions.</para>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>object</parameter></term>
+            <listitem>
+                <para>The index of the object to allocate.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>name</parameter></term>
+            <listitem>
+                <para>The name of the filesystem.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+</section>

--- a/src/references/instructions/server/object/get.xml
+++ b/src/references/instructions/server/object/get.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="get-object-instruction" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>get</title>
+    <indexterm>
+        <primary>get</primary>
+    </indexterm>
+    <para>Requests that a new stream be created, providing read access to the object stream having
+        the given name. The requested stream will be created, in response, with a body
+        instruction.</para>
+    <para>Stream names are arbitrary and dictated by the object from which they are requested, with
+        the exception of the root stream of the object itself, which has the reserved name
+            "<constant>/</constant>". The root stream of the object has the mimetype
+            "<constant>application/vnd.glyptodon.guacamole.stream-index+json</constant>", and
+        provides a simple JSON map of available stream names to their corresponding mimetypes. If
+        the object contains a hierarchy of streams, some of these streams may also be
+            "<constant>application/vnd.glyptodon.guacamole.stream-index+json</constant>".</para>
+    <para>For example, the ultimate content of the body stream provided in response to a get request
+        for the root stream of an object containing two text streams, "A" and "B", would be the
+        following:</para>
+    <informalexample>
+        <programlisting>{
+    "A" : "text/plain",
+    "B" : "text/plain"
+}</programlisting>
+    </informalexample>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>object</parameter></term>
+            <listitem>
+                <para>The index of the object to request a stream from.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>name</parameter></term>
+            <listitem>
+                <para>The name of the stream being requested from the given object.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+</section>

--- a/src/references/instructions/server/object/put.xml
+++ b/src/references/instructions/server/object/put.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="put-object-instruction" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>put</title>
+    <indexterm>
+        <primary>put</primary>
+    </indexterm>
+    <para>Allocates a new stream, associating it with the given arbitrary object and stream name.
+        The contents of the stream will later be sent with blob instructions.</para>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>object</parameter></term>
+            <listitem>
+                <para>The index of the object associated with this stream.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>stream</parameter></term>
+            <listitem>
+                <para>The index of the stream to allocate.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>mimetype</parameter></term>
+            <listitem>
+                <para>The mimetype of the data being sent.</para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+            <term><parameter>name</parameter></term>
+            <listitem>
+                <para>The name of the stream within the given object to which data is being
+                    sent.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+</section>

--- a/src/references/instructions/server/object/undefine.xml
+++ b/src/references/instructions/server/object/undefine.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="undefine-object-instruction" xmlns="http://docbook.org/ns/docbook" version="5.0"
+    xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>undefine</title>
+    <indexterm>
+        <primary>undefine</primary>
+    </indexterm>
+    <para>Undefines an existing object, allowing its index to be reused by another future object.
+        The resource associated with the original object may or may not continue to exist - it
+        simply no longer has an associated object.</para>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>object</parameter></term>
+            <listitem>
+                <para>The index of the object to undefine.</para>
+            </listitem>
+        </varlistentry>
+    </variablelist>
+</section>

--- a/src/references/protocol.xml
+++ b/src/references/protocol.xml
@@ -63,6 +63,14 @@
         <xi:include href="instructions/server/stream/pipe.xml"/>
         <xi:include href="instructions/server/stream/video.xml"/>
     </section>
+    <section xml:id="object-instructions">
+        <title>Object instructions</title>
+        <xi:include href="instructions/server/object/body.xml"/>
+        <xi:include href="instructions/server/object/filesystem.xml"/>
+        <xi:include href="instructions/server/object/get.xml"/>
+        <xi:include href="instructions/server/object/put.xml"/>
+        <xi:include href="instructions/server/object/undefine.xml"/>
+    </section>
     <section xml:id="client-handshake-instructions">
         <title>Client handshake instructions</title>
         <xi:include href="instructions/client/handshake/audio.xml"/>


### PR DESCRIPTION
This change updates the description of available streaming mechanisms, and documents the parameters and semantics of the following new instructions:
1. `body`
2. `filesystem`
3. `get`
4. `put`
5. `undefine`
