### PR TITLE
GUAC-1280: Bump versions within manual to 0.9.8 where appropriate.

### DIFF
--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -60,7 +60,7 @@
     &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-auth-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.7&lt;/version>
+    &lt;version>0.9.8&lt;/version>
     &lt;name>guacamole-auth-tutorial&lt;/name>
     &lt;url>http://guac-dev.org/&lt;/url>
 
@@ -91,13 +91,15 @@
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common&lt;/artifactId>
             &lt;version>0.9.7&lt;/version>
+            &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
         &lt;!-- Guacamole Extension API -->
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.7&lt;/version>
+            &lt;version>0.9.8&lt;/version>
+            &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
     &lt;/dependencies>

--- a/src/chapters/guacamole-ext.xml
+++ b/src/chapters/guacamole-ext.xml
@@ -162,7 +162,7 @@
                     <filename>guac-manifest.json</filename> will look something like this:</para>
             <informalexample>
                 <programlisting>{
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
     "name" : "My Extension",
     "namespace" : "my-extension"
 }</programlisting>
@@ -174,7 +174,7 @@
             <informalexample>
                 <programlisting>{
 
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
 
     "name"      : "My Extension",
     "namespace" : "my-extension",

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -464,8 +464,8 @@
                 of a <filename>.tar.gz</filename> archive which you can extract from the command
                 line:</para>
             <informalexample>
-                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.7.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-server-0.9.7/</userinput>
+                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.8.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-server-0.9.8/</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
             <para>If you want the absolute latest code, and don't care that the code hasn't been as
@@ -517,7 +517,7 @@ checking whether build environment is sane... yes
 ...
 
 ------------------------------------------------
-guacamole-server version 0.9.7
+guacamole-server version 0.9.8
 ------------------------------------------------
 
    Library status:
@@ -684,8 +684,8 @@ make[1]: Leaving directory `/home/zhz/guacamole/guacamole-server'</computeroutpu
                 <filename>.tar.gz</filename> archive which you can extract from the command
             line:</para>
         <informalexample>
-            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.7.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-client-0.9.7/</userinput>
+            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.8.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-client-0.9.8/</userinput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>As with <package>guacamole-server</package>, if you want the absolute latest code, and
@@ -779,7 +779,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
             application from the name of the <filename>.war</filename> file, you will likely want to
             rename this to simply <filename>guacamole.war</filename> while copying:</para>
         <informalexample>
-            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.7.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
+            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.8.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>Again, if you are using a different servlet container or if Tomcat is installed to a
@@ -797,7 +797,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 Starting Tomcat... OK</computeroutput>
 <prompt>#</prompt> <userinput>/etc/init.d/guacd start</userinput>
 <computeroutput>Starting guacd: SUCCESS
-guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.7 started</computeroutput>
+guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.8 started</computeroutput>
 <prompt>#</prompt></screen>
         </informalexample>
         <important>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -55,10 +55,10 @@
                 <term><filename>mysql/</filename></term>
                 <listitem>
                     <para>Contains the MySQL/MariaDB authentication extension,
-                            <filename>guacamole-auth-jdbc-mysql-0.9.7.jar</filename>, along with a
+                            <filename>guacamole-auth-jdbc-mysql-0.9.8.jar</filename>, along with a
                             <filename>schema/</filename> directory containing MySQL-specific SQL
                         scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-mysql-0.9.7.jar</filename> file will
+                            <filename>guacamole-auth-jdbc-mysql-0.9.8.jar</filename> file will
                         ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the MySQL JDBC
                         driver must be placed within <filename>GUACAMOLE_HOME/lib</filename>.</para>
@@ -75,10 +75,10 @@
                 <term><filename>postgresql/</filename></term>
                 <listitem>
                     <para>Contains the PostgreSQL authentication extension,
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.7.jar</filename>, along
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.8.jar</filename>, along
                         with a <filename>schema/</filename> directory containing PostgreSQL-specific
                         SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.7.jar</filename> file will
+                            <filename>guacamole-auth-jdbc-postgresql-0.9.8.jar</filename> file will
                         ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the PostgreSQL
                         JDBC driver must be placed within
@@ -256,9 +256,9 @@ Type "help" for help.
                     support using multiple authentication extensions at the same time.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.7.jar</filename>
+                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.8.jar</filename>
                     <emphasis>or</emphasis>
-                    <filename>guacamole-auth-jdbc-postgresql-0.9.7.jar</filename> within
+                    <filename>guacamole-auth-jdbc-postgresql-0.9.8.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
                     using MySQL/MariaDB or PostgreSQL.</para>
             </step>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -74,7 +74,7 @@
             containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-ldap-0.9.7.jar</filename></term>
+                <term><filename>guacamole-auth-ldap-0.9.8.jar</filename></term>
                 <listitem>
                     <para>The Guacamole LDAP support extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -183,7 +183,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     support using multiple authentication extensions at the same time.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-ldap-0.9.7.jar</filename> within
+                <para>Copy <filename>guacamole-auth-ldap-0.9.8.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/noauth.xml
+++ b/src/chapters/noauth.xml
@@ -35,7 +35,7 @@
             packaged as a <filename>.tar.gz</filename> file containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-noauth-0.9.7.jar</filename></term>
+                <term><filename>guacamole-auth-noauth-0.9.8.jar</filename></term>
                 <listitem>
                     <para>The NoAuth extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -66,7 +66,7 @@
                     support using multiple authentication extensions at the same time.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-noauth-0.9.7.jar</filename> within
+                <para>Copy <filename>guacamole-auth-noauth-0.9.8.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -112,7 +112,7 @@
     &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-tutorial&lt;/artifactId>
     &lt;packaging>war&lt;/packaging>
-    &lt;version>0.9.7&lt;/version>
+    &lt;version>0.9.8&lt;/version>
     &lt;name>guacamole-tutorial&lt;/name>
     &lt;url>http://guac-dev.org/&lt;/url>
 
@@ -310,7 +310,7 @@
         &lt;dependency>
             &lt;groupId>org.glyptodon.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common-js&lt;/artifactId>
-            &lt;version>0.9.7&lt;/version>
+            &lt;version>0.9.8&lt;/version>
             &lt;type>zip&lt;/type>
             &lt;scope>runtime&lt;/scope>
         &lt;/dependency>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -3,7 +3,7 @@
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <info>
         <title>Guacamole Manual</title>
-        <edition>0.9.7</edition>
+        <edition>0.9.8</edition>
         <author>
             <personname><firstname>Michael</firstname>
                 <surname>Jumper</surname></personname>
@@ -41,7 +41,7 @@
             application, etc.) to give a good starting point beyond simply looking at the Guacamole
             codebase.</para>
         <para>This particular edition of the <citetitle>Guacamole Manual</citetitle> covers
-            Guacamole version 0.9.7. New releases which create new features or break compatibility
+            Guacamole version 0.9.8. New releases which create new features or break compatibility
             will result in new editions of the user's guide, as will any necessary corrections. As
             the official documentation for the project, this book will always be freely available in
             its entirety online.</para>


### PR DESCRIPTION
As with the bumping of versions in guacamole-client, the only version that shouldn't be bumped is guacamole-common (which has not changed at all since 0.9.7):

``` console
[mjumper@dev-mjumper guacamole-client]$ git diff --stat 0.9.7..master guacamole-common
[mjumper@dev-mjumper guacamole-client]$ 
```
