### PR TITLE
change the example of guacamole.properties from 'guacd-hostname' to 'guacd-host'

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -194,7 +194,7 @@
         <example>
             <title>Example <filename>guacamole.properties</filename></title>
             <programlisting xml:id="guacamole.properties" version="5.0" xml:lang="en"># Hostname and port of guacamole proxy
-guacd-hostname: localhost
+guacd-host: localhost
 guacd-port:     4822</programlisting>
         </example>
     </section>


### PR DESCRIPTION
It makes me feel confused at first glance.
The description above show that the properties has guacd-host guacd-port guacd-ssl, but the example down use guacd-hostname: localhost.
I don't know which one should I use.
