### PR TITLE
GUAC-1435: Do not encourage use of deprecated GuacamoleSession

### DIFF
--- a/src/chapters/guacamole-common.xml
+++ b/src/chapters/guacamole-common.xml
@@ -48,33 +48,19 @@
                 <methodname>doConnect()</methodname> does not create the tunnel,
             communication between the JavaScript client and guacd cannot take
             place, which is an ideal power to have as an authenticator.</para>
-        <para>The <methodname>doConnect()</methodname> function is expected to
-            "attach" a <classname>GuacamoleTunnel</classname> to the web
-            session, abstracted by <classname>GuacamoleSession</classname>.
-            Attaching a tunnel to the session allows future tunnel requests to
-            retrieve the same tunnel and use it, thus allowing one tunnel to be
-            split across multiple requests. Assuming the
-                <methodname>doConnect()</methodname> function successfully
-            creates the tunnel, it must then return the created tunnel. The
-            already-implemented parts of
-                <classname>GuacamoleHTTPTunnelServlet</classname> then return
-            the unique identifier of this tunnel to the JavaScript client,
-            allowing its own tunnel implementation to continue to communicate
-            with the tunnel existing on the Java side.</para>
-        <para>Instances of <classname>GuacamoleTunnel</classname> are created
-            associated with a <classname>GuacamoleSocket</classname>, which is
-            the abstract interface surrounding the low-level connection to
-            guacd. Overall, there is a socket
-                (<classname>GuacamoleSocket</classname>) which provides a TCP
-            connection to guacd. This socket is exposed to
-                <classname>GuacamoleTunnel</classname>, which provides abstract
-            protocol access around what is actually (but secretly, through the
-            abstraction of the API) a TCP socket. The
-                <classname>GuacamoleSession</classname> allows instances of
-                <classname>GuacamoleTunnel</classname> to be shared across
-            requests, and <classname>GuacamoleHTTPTunnelServlet</classname>
-            pulls these tunnels from the session as necessary to fulfill
-            requests made by the JavaScript client.</para>
+        <para>The <methodname>doConnect()</methodname> function is expected to return a new
+                <classname>GuacamoleTunnel</classname>, but it is completely up to the
+            implementation to decide how that tunnel is to be created. The already-implemented parts
+            of <classname>GuacamoleHTTPTunnelServlet</classname> then return the unique identifier
+            of this tunnel to the JavaScript client, allowing its own tunnel implementation to
+            continue to communicate with the tunnel existing on the Java side.</para>
+        <para>Instances of <classname>GuacamoleTunnel</classname> are created associated with a
+                <classname>GuacamoleSocket</classname>, which is the abstract interface surrounding
+            the low-level connection to guacd. Overall, there is a socket
+                (<classname>GuacamoleSocket</classname>) which provides a TCP connection to guacd.
+            This socket is exposed to <classname>GuacamoleTunnel</classname>, which provides
+            abstract protocol access around what is actually (but secretly, through the abstraction
+            of the API) a TCP socket.</para>
         <para>The Guacamole web application extends this tunnel servlet in order
             to implement authentication at the lowest possible level,
             effectively prohibiting communication between the client and any
@@ -92,15 +78,8 @@
         // Connect to guacd here (this is a STUB)
         GuacamoleSocket socket;
 
-        // Establish the tunnel using the connected socket
-        GuacamoleTunnel tunnel = new GuacamoleTunnel(socket);
-
-        // Attach tunnel to session
-        GuacamoleSession session = new GuacamoleSession(httpSession);
-        session.attachTunnel(tunnel);
-
-        // Return pre-attached tunnel
-        return tunnel;
+        // Return a new tunnel which uses the connected socket
+        return new GuacamoleTunnel(socket);
 
     }
 

--- a/src/chapters/guacamole-common.xml
+++ b/src/chapters/guacamole-common.xml
@@ -79,7 +79,7 @@
         GuacamoleSocket socket;
 
         // Return a new tunnel which uses the connected socket
-        return new GuacamoleTunnel(socket);
+        return new SimpleGuacamoleTunnel(socket);
 
     }
 

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -359,7 +359,6 @@
 package org.glyptodon.guacamole.net.example;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.net.GuacamoleSocket;
 import org.glyptodon.guacamole.net.GuacamoleTunnel;
@@ -367,7 +366,6 @@ import org.glyptodon.guacamole.net.InetGuacamoleSocket;
 import org.glyptodon.guacamole.protocol.ConfiguredGuacamoleSocket;
 import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
 import org.glyptodon.guacamole.servlet.GuacamoleHTTPTunnelServlet;
-import org.glyptodon.guacamole.servlet.GuacamoleSession;
 
 public class TutorialGuacamoleTunnelServlet
     extends GuacamoleHTTPTunnelServlet {
@@ -389,16 +387,8 @@ public class TutorialGuacamoleTunnelServlet
                 config
         );
 
-        // Establish the tunnel using the connected socket
-        GuacamoleTunnel tunnel = new GuacamoleTunnel(socket);
-
-        // Attach tunnel to session
-        HttpSession httpSession = request.getSession(true);
-        GuacamoleSession session = new GuacamoleSession(httpSession);
-        session.attachTunnel(tunnel);
-
-        // Return pre-attached tunnel
-        return tunnel;
+        // Return a new tunnel which uses the connected socket
+        return new GuacamoleTunnel(socket);;
 
     }
 

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -156,10 +156,13 @@
                 successfully. However, as the <filename>web.xml</filename> refers to a "welcome
                 file" called <filename>index.html</filename> (which will ultimately contain our
                 client), we need to put this in place so the servlet container will have something
-                to serve. For now, this can be anything - we will replace it later:</para>
+                to serve. This file, as well as any other future static files, belongs within
+                    <filename>src/main/webapp</filename>.</para>
+            <para>For now, this file can contain anything, since the other parts of our
+                Guacamole-driven web application are not written yet. It is a placeholder which we
+                will replace later:</para>
             <informalexample>
                 <programlisting>&lt;!DOCTYPE HTML>
-
 &lt;html>
 
     &lt;head>
@@ -167,9 +170,7 @@
     &lt;/head>
 
     &lt;body>
-
         &lt;p>Hello World&lt;/p>
-
     &lt;/body>
 
 &lt;/html></programlisting>
@@ -355,14 +356,14 @@
             <para>Create a new file, <filename>TutorialGuacamoleTunnelServlet.java</filename>,
                 defining a basic implementation of a tunnel servlet class:</para>
             <informalexample>
-                <programlisting>
-package org.glyptodon.guacamole.net.example;
+                <programlisting>package org.glyptodon.guacamole.net.example;
 
 import javax.servlet.http.HttpServletRequest;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.net.GuacamoleSocket;
 import org.glyptodon.guacamole.net.GuacamoleTunnel;
 import org.glyptodon.guacamole.net.InetGuacamoleSocket;
+import org.glyptodon.guacamole.net.SimpleGuacamoleTunnel;
 import org.glyptodon.guacamole.protocol.ConfiguredGuacamoleSocket;
 import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
 import org.glyptodon.guacamole.servlet.GuacamoleHTTPTunnelServlet;
@@ -388,14 +389,14 @@ public class TutorialGuacamoleTunnelServlet
         );
 
         // Return a new tunnel which uses the connected socket
-        return new GuacamoleTunnel(socket);;
+        return new SimpleGuacamoleTunnel(socket);;
 
     }
 
 }</programlisting>
             </informalexample>
             <para>Place this file in the
-                    <filename>src/main/java/net/sourceforge/guacamole/net/example</filename>
+                    <filename>src/main/java/org/glyptodon/guacamole/net/example</filename>
                 subdirectory of the project. The initial part of this subdirectory,
                     <filename>src/main/java</filename>, is the path required by Maven, while the
                 rest is the directory required by Java based on the package associated with the
@@ -496,8 +497,7 @@ public class TutorialGuacamoleTunnelServlet
                 their corresponding input events, calling whichever function of the Guacamole client
                 is appropriate to send the input event through the tunnel to guacd:</para>
             <informalexample>
-                <programlisting>        
-        ...
+                <programlisting>        ...
 
         &lt;!-- Init -->
         &lt;script type="text/javascript"> /* &lt;![CDATA[ */
@@ -524,7 +524,9 @@ public class TutorialGuacamoleTunnelServlet
                 guac.sendKeyEvent(0, keysym);
             };
 
-        /* ]]&gt; */ &lt;/script></programlisting>
+        /* ]]&gt; */ &lt;/script>
+
+        ...</programlisting>
             </informalexample>
         </section>
     </section>

--- a/tutorials/guacamole-tutorial/.gitignore
+++ b/tutorials/guacamole-tutorial/.gitignore
@@ -1,0 +1,3 @@
+*~
+target/
+META-INF/

--- a/tutorials/guacamole-tutorial/pom.xml
+++ b/tutorials/guacamole-tutorial/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glyptodon.guacamole</groupId>
+    <artifactId>guacamole-tutorial</artifactId>
+    <packaging>war</packaging>
+    <version>0.9.9</version>
+    <name>guacamole-tutorial</name>
+    <url>http://guac-dev.org/</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+
+            <!-- Compile using Java 1.6 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+
+            <!-- Overlay guacamole-common-js (zip) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <overlays>
+                        <overlay>
+                            <groupId>org.glyptodon.guacamole</groupId>
+                            <artifactId>guacamole-common-js</artifactId>
+                            <type>zip</type>
+                        </overlay>
+                    </overlays>
+                </configuration>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+    <dependencies>
+
+        <!-- Servlet API -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Main Guacamole library -->
+        <dependency>
+            <groupId>org.glyptodon.guacamole</groupId>
+            <artifactId>guacamole-common</artifactId>
+            <version>0.9.9</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Guacamole JavaScript library -->
+        <dependency>
+            <groupId>org.glyptodon.guacamole</groupId>
+            <artifactId>guacamole-common-js</artifactId>
+            <version>0.9.9</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/tutorials/guacamole-tutorial/src/main/java/org/glyptodon/guacamole/net/example/TutorialGuacamoleTunnelServlet.java
+++ b/tutorials/guacamole-tutorial/src/main/java/org/glyptodon/guacamole/net/example/TutorialGuacamoleTunnelServlet.java
@@ -1,0 +1,38 @@
+package org.glyptodon.guacamole.net.example;
+
+import javax.servlet.http.HttpServletRequest;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.net.GuacamoleSocket;
+import org.glyptodon.guacamole.net.GuacamoleTunnel;
+import org.glyptodon.guacamole.net.InetGuacamoleSocket;
+import org.glyptodon.guacamole.net.SimpleGuacamoleTunnel;
+import org.glyptodon.guacamole.protocol.ConfiguredGuacamoleSocket;
+import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
+import org.glyptodon.guacamole.servlet.GuacamoleHTTPTunnelServlet;
+
+public class TutorialGuacamoleTunnelServlet
+    extends GuacamoleHTTPTunnelServlet {
+
+    @Override
+    protected GuacamoleTunnel doConnect(HttpServletRequest request)
+        throws GuacamoleException {
+
+        // Create our configuration
+        GuacamoleConfiguration config = new GuacamoleConfiguration();
+        config.setProtocol("vnc");
+        config.setParameter("hostname", "localhost");
+        config.setParameter("port", "5901");
+        config.setParameter("password", "potato");
+
+        // Connect to guacd - everything is hard-coded here.
+        GuacamoleSocket socket = new ConfiguredGuacamoleSocket(
+                new InetGuacamoleSocket("localhost", 4822),
+                config
+        );
+
+        // Return a new tunnel which uses the connected socket
+        return new SimpleGuacamoleTunnel(socket);
+
+    }
+
+}

--- a/tutorials/guacamole-tutorial/src/main/webapp/WEB-INF/web.xml
+++ b/tutorials/guacamole-tutorial/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5"
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+                        http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <!-- Basic config -->
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+
+    <!-- Guacamole Tunnel Servlet -->
+    <servlet>
+        <description>Tunnel servlet.</description>
+        <servlet-name>Tunnel</servlet-name>
+        <servlet-class>
+            org.glyptodon.guacamole.net.example.TutorialGuacamoleTunnelServlet
+        </servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Tunnel</servlet-name>
+        <url-pattern>/tunnel</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/tutorials/guacamole-tutorial/src/main/webapp/index.html
+++ b/tutorials/guacamole-tutorial/src/main/webapp/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML>
+<html>
+
+    <head>
+        <title>Guacamole Tutorial</title>
+    </head>
+
+    <body>
+
+        <!-- Guacamole -->
+        <script type="text/javascript"
+            src="guacamole-common-js/all.min.js"></script>
+
+        <!-- Display -->
+        <div id="display"></div>
+
+        <!-- Init -->
+        <script type="text/javascript"> /* <![CDATA[ */
+
+            // Get display div from document
+            var display = document.getElementById("display");
+
+            // Instantiate client, using an HTTP tunnel for communications.
+            var guac = new Guacamole.Client(
+                new Guacamole.HTTPTunnel("tunnel")
+            );
+
+            // Add client to display div
+            display.appendChild(guac.getDisplay().getElement());
+            
+            // Error handler
+            guac.onerror = function(error) {
+                alert(error);
+            };
+
+            // Connect
+            guac.connect();
+
+            // Disconnect on close
+            window.onunload = function() {
+                guac.disconnect();
+            }
+
+            // Mouse
+            var mouse = new Guacamole.Mouse(guac.getDisplay().getElement());
+
+            mouse.onmousedown = 
+            mouse.onmouseup   =
+            mouse.onmousemove = function(mouseState) {
+                guac.sendMouseState(mouseState);
+            };
+
+            // Keyboard
+            var keyboard = new Guacamole.Keyboard(document);
+
+            keyboard.onkeydown = function (keysym) {
+                guac.sendKeyEvent(1, keysym);
+            };
+
+            keyboard.onkeyup = function (keysym) {
+                guac.sendKeyEvent(0, keysym);
+            };
+
+        /* ]]> */ </script>
+
+    </body>
+
+</html>


### PR DESCRIPTION
This change brings the documentation up-to-date with the changes made for [GUAC-1427](https://glyptodon.org/jira/browse/GUAC-1427) (namely deprecating `GuacamoleSession`) while also verifying that the web application tutorial is correct by **actually going through the tutorial and running the resulting webapp**. Any problems noticed as a result were also corrected.
