### PR TITLE
GUAC-1436: Do not encourage use of deprecated GuacamoleProperties class

### DIFF
--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -122,7 +122,12 @@ import org.glyptodon.guacamole.net.auth.Credentials;
 import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
 
 public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider {
-       
+
+    @Override
+    public String getIdentifier() {
+        return "tutorial";
+    }
+
     @Override
     public Map&lt;String, GuacamoleConfiguration>
         getAuthorizedConfigurations(Credentials credentials)
@@ -136,19 +141,21 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
 }</programlisting>
         </example>
         <para>To conform with Maven, this skeleton file must be placed within
-                <filename>src/main/java/net/sourceforge/guacamole/auth</filename> as
+                <filename>src/main/java/org/glyptodon/guacamole/auth</filename> as
                 <filename>TutorialAuthenticationProvider.java</filename>.</para>
         <para>Notice how simple the authentication provider is. The
                 <classname>AuthenticationProvider</classname> interface requires nothing more than a
-            single <methodname>getAuthorizedConfigurations()</methodname> implementation, which must
+            unique identifier (we will use "tutorial") and a single
+                <methodname>getAuthorizedConfigurations()</methodname> implementation, which must
             return a <classname>Map</classname> of <classname>GuacamoleConfiguration</classname>
             each associated with some arbitrary unique ID. This unique ID will be presented to the
             user in the connection list after they log in.</para>
-        <para>For now, we just return <varname>null</varname>, which will cause Guacamole to report
-            an invalid login for every attempt. Note that there is a difference in semantics between
-            returning an empty map and returning <varname>null</varname>, as the former indicates
-            the credentials are authorized but simply have no associated configurations, while the
-            latter indicates the credentials are not authorized at all.</para>
+        <para>For now, <methodname>getAuthorizedConfigurations()</methodname> will just return
+                <varname>null</varname>. This will cause Guacamole to report an invalid login for
+            every attempt. Note that there is a difference in semantics between returning an empty
+            map and returning <varname>null</varname>, as the former indicates the credentials are
+            authorized but simply have no associated configurations, while the latter indicates the
+            credentials are not authorized at all.</para>
     </section>
     <section xml:id="user-auth-example">
         <title>Actually authenticating the user</title>
@@ -284,18 +291,21 @@ public Map&lt;String, GuacamoleConfiguration>
     getAuthorizedConfigurations(Credentials credentials)
     throws GuacamoleException {
 
-    // Get username
-    String username = GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_USER
+    // Get the Guacamole server environment
+    Environment environment = new LocalEnvironment();
+
+    // Get username from guacamole.properties
+    String username = environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_USER
     );      
 
     // If wrong username, fail
     if (!username.equals(credentials.getUsername()))
         return null;
 
-    // Get password
-    String password = GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_PASSWORD
+    // Get password from guacamole.properties
+    String password = environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_PASSWORD
     );      
 
     // If wrong password, fail
@@ -326,18 +336,21 @@ public Map&lt;String, GuacamoleConfiguration>
     getAuthorizedConfigurations(Credentials credentials)
     throws GuacamoleException {
 
-    // Get username
-    String username = GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_USER
+    // Get the Guacamole server environment
+    Environment environment = new LocalEnvironment();
+
+    // Get username from guacamole.properties
+    String username = environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_USER
     );      
 
     // If wrong username, fail
     if (!username.equals(credentials.getUsername()))
         return null;
 
-    // Get password
-    String password = GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_PASSWORD
+    // Get password from guacamole.properties
+    String password = environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_PASSWORD
     );      
 
     // If wrong password, fail
@@ -352,19 +365,19 @@ public Map&lt;String, GuacamoleConfiguration>
     GuacamoleConfiguration config = new GuacamoleConfiguration();
 
     // Set protocol specified in properties
-    config.setProtocol(GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_PROTOCOL
+    config.setProtocol(environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_PROTOCOL
     ));
 
     // Set all parameters, splitting at commas
-    for (String parameterValue : GuacamoleProperties.getRequiredProperty(
-        TutorialProperties.TUTORIAL_PARAMETERS
+    for (String parameterValue : environment.getRequiredProperty(
+        TutorialGuacamoleProperties.TUTORIAL_PARAMETERS
     ).split(",\\s*")) {
 
         // Find the equals sign
         int equals = parameterValue.indexOf('=');
         if (equals == -1)
-            throw new GuacamoleException("Required equals sign missing");
+            throw new GuacamoleServerException("Required equals sign missing");
 
         // Get name and value from parameter string
         String name = parameterValue.substring(0, equals);
@@ -375,7 +388,7 @@ public Map&lt;String, GuacamoleConfiguration>
 
     }
 
-    configs.put("DEFAULT", config);
+    configs.put("Tutorial Connection", config);
     return configs;
 
 }</programlisting>

--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -121,6 +121,11 @@ import org.glyptodon.guacamole.net.auth.simple.SimpleAuthenticationProvider;
 import org.glyptodon.guacamole.net.auth.Credentials;
 import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
 
+/**
+ * Authentication provider implementation intended to demonstrate basic use
+ * of Guacamole's extension API. The credentials and connection information for
+ * a single user are stored directly in guacamole.properties.
+ */
 public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider {
 
     @Override
@@ -208,6 +213,11 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
 
 import org.glyptodon.guacamole.properties.StringGuacamoleProperty;
 
+/**
+ * Utility class containing all properties used by the custom authentication
+ * tutorial. The properties defined here must be specified within
+ * guacamole.properties to configure the tutorial authentication provider.
+ */
 public class TutorialGuacamoleProperties {
 
     /**

--- a/src/chapters/guacamole-common.xml
+++ b/src/chapters/guacamole-common.xml
@@ -10,14 +10,12 @@
     <indexterm>
         <primary><package>guacamole-common</package></primary>
     </indexterm>
-    <para>The Java API provided by the Guacamole project is called
-        guacamole-common. It provides a basic means of tunneling data between
-        the JavaScript client provided by guacamole-common-js and the native
-        proxy daemon, guacd. There are other classes provided as well which make
-        dealing with the Guacamole protocol and reading from
-            <filename>guacamole.properties</filename> easier, but in general,
-        the purpose of this library is to facilitate the creation of custom
-        tunnels between the JavaScript client and guacd.</para>
+    <para>The Java API provided by the Guacamole project is called guacamole-common. It provides a
+        basic means of tunneling data between the JavaScript client provided by guacamole-common-js
+        and the native proxy daemon, guacd, and for dealing with the Guacamole protocol. The purpose
+        of this library is to facilitate the creation of custom tunnels between the JavaScript
+        client and guacd, allowing your Guacamole-driven web application to enforce its own security
+        model, if any, and dictate exactly what connections are established.</para>
     <section xml:id="java-http-tunnel">
         <title>HTTP tunnel</title>
         <para>The Guacamole Java API implements the HTTP tunnel using a servlet
@@ -160,84 +158,5 @@
                     <classname>GuacamoleWriter</classname> will be
                 sufficient.</para>
         </section>
-    </section>
-    <section xml:id="reading-properties">
-        <title>Reading properties</title>
-        <para>The Guacamole Java API provides simple access to
-                <filename>guacamole.properties</filename> for convenience,
-            although such support is not strictly required. This support is
-            provided through the <classname>GuacamoleProperies</classname>
-            utility class, which cannot be instantiated and provides two simple
-            property retrieval functions: <methodname>getProperty()</methodname>
-            and <methodname>getRequiredProperty()</methodname>, the difference
-            being that the former can return <constant>null</constant> if a
-            property is not defined, while the latter will throw an exception
-            instead. These functions are generic and typesafe and will return
-            the correct Java class or type when given an instance of a
-            property.</para>
-        <para>In Guacamole, each property is declared as an implementation of
-                <classname>GuacamoleProperty</classname>, and must provide an
-            implementation of <methodname>getName()</methodname>, which returns
-            the name of the property as it should exist within
-                <filename>guacamole.properties</filename>, and
-                <methodname>parseValue()</methodname>, which is given the
-                <classname>String</classname> value of the property as read from
-                <filename>guacamole.properties</filename>, and must return the
-            declared type of the <classname>GuacamoleProperty</classname>
-            implementation. A good example of how this works is the
-                <classname>IntegerGuacamoleProperty</classname> implementation
-            included within guacamole-common:</para>
-        <informalexample>
-            <programlisting>public abstract class IntegerGuacamoleProperty implements GuacamoleProperty&lt;Integer> {
-
-    @Override
-    public Integer parseValue(String value) throws GuacamoleException {
-
-        // If no property provided, return null.
-        if (value == null)
-            return null;
-
-        try {
-            Integer integer = new Integer(value);
-            return integer;
-        }
-        catch (NumberFormatException e) {
-            throw new GuacamoleServerException("Property \"" + getName() +
-                "\" must be an integer.", e);
-        }
-
-    }
-
-}</programlisting>
-        </informalexample>
-        <para>Notice that this implementation does not actually provide
-                <methodname>getName()</methodname>. Instead, it only implements
-                <methodname>parseValue()</methodname>, the intent being to make
-            other developers' lives easier when they need to retrieve an integer
-            property from <filename>guacamole.properties</filename>. Using this
-            class, retrieving an integer property is simple:</para>
-        <informalexample>
-            <programlisting>public class MyClass {
-
-    public static final IntegerGuacamoleProperty IMPORTANT_INT =
-        new IntegerGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "important-int"; }
-
-    };
-
-}
-
-... later on within MyClass ...
-
-int important = GuacamoleProperties.getRequiredProperty(IMPORTANT_INT);</programlisting>
-        </informalexample>
-        <para>guacamole-common provides a couple of similar classes for
-            retrieving common types of properties, such as a
-                <classname>String</classname> or <classname>File</classname>,
-            and implementing your own to facilitate properties that parse into
-            arrays or a <classname>List</classname>, etc. should be reasonably
-            simple.</para>
     </section>
 </chapter>

--- a/tutorials/guacamole-auth-tutorial/.gitignore
+++ b/tutorials/guacamole-auth-tutorial/.gitignore
@@ -1,0 +1,3 @@
+*~
+target/
+META-INF/

--- a/tutorials/guacamole-auth-tutorial/pom.xml
+++ b/tutorials/guacamole-auth-tutorial/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                        http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glyptodon.guacamole</groupId>
+    <artifactId>guacamole-auth-tutorial</artifactId>
+    <packaging>jar</packaging>
+    <version>0.9.9</version>
+    <name>guacamole-auth-tutorial</name>
+    <url>http://guac-dev.org/</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+
+            <!-- Written for 1.6 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+
+        <!-- Guacamole Java API -->
+        <dependency>
+            <groupId>org.glyptodon.guacamole</groupId>
+            <artifactId>guacamole-common</artifactId>
+            <version>0.9.9</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Guacamole Extension API -->
+        <dependency>
+            <groupId>org.glyptodon.guacamole</groupId>
+            <artifactId>guacamole-ext</artifactId>
+            <version>0.9.9</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialAuthenticationProvider.java
+++ b/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialAuthenticationProvider.java
@@ -1,0 +1,82 @@
+package org.glyptodon.guacamole.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.GuacamoleServerException;
+import org.glyptodon.guacamole.environment.Environment;
+import org.glyptodon.guacamole.environment.LocalEnvironment;
+import org.glyptodon.guacamole.net.auth.simple.SimpleAuthenticationProvider;
+import org.glyptodon.guacamole.net.auth.Credentials;
+import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
+
+public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider {
+       
+    @Override
+    public String getIdentifier() {
+        return "tutorial";
+    }
+
+    @Override
+    public Map<String, GuacamoleConfiguration>
+        getAuthorizedConfigurations(Credentials credentials)
+        throws GuacamoleException {
+
+        // Get the Guacamole server environment
+        Environment environment = new LocalEnvironment();
+
+        // Get username from guacamole.properties
+        String username = environment.getRequiredProperty(
+            TutorialGuacamoleProperties.TUTORIAL_USER
+        );
+
+        // If wrong username, fail
+        if (!username.equals(credentials.getUsername()))
+            return null;
+
+        // Get password from guacamole.properties
+        String password = environment.getRequiredProperty(
+            TutorialGuacamoleProperties.TUTORIAL_PASSWORD
+        );
+
+        // If wrong password, fail
+        if (!password.equals(credentials.getPassword()))
+            return null;
+
+        // Successful login. Return configurations.
+        Map<String, GuacamoleConfiguration> configs =
+            new HashMap<String, GuacamoleConfiguration>();
+
+        // Create new configuration
+        GuacamoleConfiguration config = new GuacamoleConfiguration();
+
+        // Set protocol specified in properties
+        config.setProtocol(environment.getRequiredProperty(
+            TutorialGuacamoleProperties.TUTORIAL_PROTOCOL
+        ));
+
+        // Set all parameters, splitting at commas
+        for (String parameterValue : environment.getRequiredProperty(
+            TutorialGuacamoleProperties.TUTORIAL_PARAMETERS
+        ).split(",\\s*")) {
+
+            // Find the equals sign
+            int equals = parameterValue.indexOf('=');
+            if (equals == -1)
+                throw new GuacamoleServerException("Required equals sign missing");
+
+            // Get name and value from parameter string
+            String name = parameterValue.substring(0, equals);
+            String value = parameterValue.substring(equals+1);
+
+            // Set parameter as specified
+            config.setParameter(name, value);
+
+        }
+
+        configs.put("Tutorial Connection", config);
+        return configs;
+
+    }
+
+}

--- a/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialAuthenticationProvider.java
+++ b/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialAuthenticationProvider.java
@@ -10,6 +10,11 @@ import org.glyptodon.guacamole.net.auth.simple.SimpleAuthenticationProvider;
 import org.glyptodon.guacamole.net.auth.Credentials;
 import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
 
+/**
+ * Authentication provider implementation intended to demonstrate basic use
+ * of Guacamole's extension API. The credentials and connection information for
+ * a single user are stored directly in guacamole.properties.
+ */
 public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider {
        
     @Override

--- a/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialGuacamoleProperties.java
+++ b/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialGuacamoleProperties.java
@@ -1,0 +1,59 @@
+package org.glyptodon.guacamole.auth;
+
+import org.glyptodon.guacamole.properties.StringGuacamoleProperty;
+
+public class TutorialGuacamoleProperties {
+
+    /**
+     * This class should not be instantiated.
+     */
+    private TutorialGuacamoleProperties() {}
+
+    /**
+     * The only user to allow.
+     */
+    public static final StringGuacamoleProperty TUTORIAL_USER = 
+        new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "tutorial-user"; }
+
+    };
+
+    /**
+     * The password required for the specified user.
+     */
+    public static final StringGuacamoleProperty TUTORIAL_PASSWORD = 
+        new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "tutorial-password"; }
+
+    };
+
+
+    /**
+     * The protocol to use when connecting.
+     */
+    public static final StringGuacamoleProperty TUTORIAL_PROTOCOL = 
+        new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "tutorial-protocol"; }
+
+    };
+
+
+    /**
+     * All parameters associated with the connection, as a comma-delimited
+     * list of name="value" 
+     */
+    public static final StringGuacamoleProperty TUTORIAL_PARAMETERS = 
+        new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "tutorial-parameters"; }
+
+    };
+
+}

--- a/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialGuacamoleProperties.java
+++ b/tutorials/guacamole-auth-tutorial/src/main/java/org/glyptodon/guacamole/auth/TutorialGuacamoleProperties.java
@@ -2,6 +2,11 @@ package org.glyptodon.guacamole.auth;
 
 import org.glyptodon.guacamole.properties.StringGuacamoleProperty;
 
+/**
+ * Utility class containing all properties used by the custom authentication
+ * tutorial. The properties defined here must be specified within
+ * guacamole.properties to configure the tutorial authentication provider.
+ */
 public class TutorialGuacamoleProperties {
 
     /**


### PR DESCRIPTION
As with #46, this change removes mention of the deprecated `GuacamoleProperties` class from the documentation, replacing all use within tutorials, etc. with `Environment` and `LocalEnvironment`. I have gone through the entire custom auth tutorial and added the resulting source as a means of verifying its correctness. There were some additional changes necessary to fix the tutorial:
1. `getIdentifier()` was missing (necessary now that multiple extensions can be loaded at a time).
2. The source directory did not match the package of each class.
3. The `TutorialGuacamoleProperties` class was erroneously used as `TutorialProperties`.
